### PR TITLE
Return a promise to allow simplified waiting for async.

### DIFF
--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import wait from 'ember-test-helpers/wait';
 
 const { run, $ } = Ember;
 
@@ -22,6 +23,8 @@ function focus(el) {
       });
     }
   }
+
+  return wait();
 }
 
 export function click(selector, options = {}) {
@@ -38,4 +41,6 @@ export function click(selector, options = {}) {
   focus(element);
   run(() => element.dispatchEvent(mouseup));
   run(() => element.dispatchEvent(click));
+
+  return wait();
 }


### PR DESCRIPTION
Returning the `wait()` promise, allows consumers to have a  nice mechanism to allow async that is triggered by these helpers to interact with the world after all things have settled.

For example:

```js
test('foo', async function(assert) {
  this.render(hbs`{{some-component}}`);

  await click('.selector');

  assert.equal('whatever', 'lol');
});
```