### PR TITLE
Add dummy app component/test, use rootElement to select

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /bower_components
 
 # misc
+.DS_Store
 /.sass-cache
 /connect.lock
 /coverage/*

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 /bower_components
 
 # misc
-.DS_Store
 /.sass-cache
 /connect.lock
 /coverage/*

--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -7,6 +7,9 @@ const DEFAULT_EVENT_OPTIONS = { canBubble: true, cancelable: true };
 const KEYBOARD_EVENT_TYPES = ['keydown', 'keypress', 'keyup'];
 const MOUSE_EVENT_TYPES = ['click', 'mousedown', 'mouseup', 'dblclick', 'mouseenter', 'mouseleave', 'mousemove', 'mouseout', 'mouseover'];
 
+import config from 'dummy/config/environment';
+const { APP: { rootElement } } = config;
+
 function focus(el) {
   if (!el) { return; }
 
@@ -111,7 +114,7 @@ function buildKeyboardEvent(type, options = {}) {
 }
 
 export function click(selector, options = {}) {
-  let el = document.querySelector(selector);
+  let el = document.querySelector(`${rootElement} ${selector}`);
   run(() => fireEvent(el, 'mousedown', options));
   focus(el);
   run(() => fireEvent(el, 'mouseup', options));
@@ -120,7 +123,7 @@ export function click(selector, options = {}) {
 }
 
 export function fillIn(selector, text) {
-  let el = document.querySelector(selector);
+  let el = document.querySelector(`${rootElement} ${selector}`);
   run(() => focus(el));
   run(() => el.value = text);
   run(() => fireEvent(el, 'input'));
@@ -129,7 +132,7 @@ export function fillIn(selector, text) {
 }
 
 export function triggerEvent(selector, type, options) {
-  let el = document.querySelector(selector);
+  let el = document.querySelector(`${rootElement} ${selector}`);
   run(() => fireEvent(el, type, options));
   return wait();
 }

--- a/addon-test-support/settings.js
+++ b/addon-test-support/settings.js
@@ -4,14 +4,34 @@
   @class TestSupportSettings
 */
 class TestSupportSettings {
-  constructor(init = { rootElement: '#ember-testing'}) {
+
+  constructor(init = { rootElement: '#ember-testing', $: false}) {
     this._rootElement = init.rootElement;
+    this._useJQueryWrapper = init.$;
   }
+
+  /*
+    Setting for Ember app root element, default is #ember-testing
+
+    @public rootElement
+    @type String
+  */
   get rootElement() {
     return this._rootElement;
   }
   set rootElement(value) {
     this._rootElement = value;
+  }
+
+  /*
+    @public useJQueryWrapper
+    @type Boolean
+  */
+  get useJQueryWrapper() {
+    return this._useJQueryWrapper;
+  }
+  set useJQueryWrapper(value) {
+    this._useJQueryWrapper = value;
   }
 }
 

--- a/addon-test-support/settings.js
+++ b/addon-test-support/settings.js
@@ -1,0 +1,20 @@
+/*
+  Options for use with test helpers, e.g. root element selector
+
+  @class TestSupportSettings
+*/
+class TestSupportSettings {
+  constructor(init = { rootElement: '#ember-testing'}) {
+    this._rootElement = init.rootElement;
+  }
+  get rootElement() {
+    return this._rootElement;
+  }
+  set rootElement(value) {
+    this._rootElement = value;
+  }
+}
+
+const settings = new TestSupportSettings();
+
+export default settings;

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -2,9 +2,7 @@
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
-  var app = new EmberAddon(defaults, {
-    // Add options here
-  });
+  var app = new EmberAddon(defaults);
 
   /*
     This build file specifies the options for the dummy test app of this

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "events"
   ],
   "license": "MIT",
-  "author": "Miguel Camba",
+  "contributors": [
+    "Miguel Camba <miguel.camba@gmail.com> (http://miguelcamba.com)",
+    "Bill Heaton <pixelhandler@gmail.com> (https://pixelhandler.com)"
+  ],
   "directories": {
     "doc": "doc",
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
+    "broccoli-concat": "^3.2.2",
     "ember-cli-babel": "^5.1.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "broccoli-concat": "^3.2.2",
     "ember-cli-babel": "^5.1.7"
   },
   "devDependencies": {

--- a/tests/dummy/app/components/x-form.js
+++ b/tests/dummy/app/components/x-form.js
@@ -1,0 +1,44 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: 'form',
+
+  agreed: false,
+
+  inputValue: '',
+
+  isChecked: false,
+
+  message: '',
+
+  selectedValue: '',
+
+  textareaValue: '',
+
+  actions: {
+    showTerms() {
+      this.element.querySelector('.terms-hidden').classList.remove('terms-hidden');
+    },
+    agree() {
+      this.set('agreed', true);
+    },
+    selected(evt) {
+      this.set('selectedValue', evt.target.value);
+      this.get('onSelect')(evt.target.value);
+    }
+  },
+
+  keyUp(evt) {
+    if (evt.keyCode === 13) {
+      this.submit(evt);
+    }
+  },
+
+  submit() {
+    if (this.get('agreed')) {
+      this.set('message', 'All your base are mine');
+    } else {
+      this.set('message', 'you must agree to my terms');
+    }
+  }
+});

--- a/tests/dummy/app/components/x-form.js
+++ b/tests/dummy/app/components/x-form.js
@@ -25,6 +25,9 @@ export default Ember.Component.extend({
     selected(evt) {
       this.set('selectedValue', evt.target.value);
       this.get('onSelect')(evt.target.value);
+    },
+    submit() {
+      this.submit()
     }
   },
 

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,0 +1,3 @@
+.terms-hidden {
+  visibility: hidden;
+}

--- a/tests/dummy/app/templates/components/x-form.hbs
+++ b/tests/dummy/app/templates/components/x-form.hbs
@@ -21,4 +21,6 @@
 
 <p class="message">{{message}}</p>
 
+<a href="mailto:legal@me.com">Email Legal</a>
+
 {{yield}}

--- a/tests/dummy/app/templates/components/x-form.hbs
+++ b/tests/dummy/app/templates/components/x-form.hbs
@@ -1,0 +1,24 @@
+<input type="text" value={{inputValue}}>
+
+<input type="checkbox" checked={{isChecked}}>
+
+<select onchange={{action "selected"}}>
+  <option value="" selected="selected">Choose One</option>
+  <option value="blue">blue</option>
+  <option value="red">red</option>
+</select>
+
+<textarea>{{textareaValue}}</textarea>
+
+<a href="#" class="terms-show" {{action 'showTerms'}}>Agree to Terms and conditions</a>
+
+<section class="terms-hidden">
+  <p>I have read this bull and agree to it's mastery of my freedom and anonymity</p>
+  <button {{action 'agree'}} class="terms-agree">I accept your terms, darn it</button>
+</section>
+
+<button type="submit" {{action "submit"}}>Submit</button>
+
+<p class="message">{{message}}</p>
+
+{{yield}}

--- a/tests/integration/components/x-form-test.js
+++ b/tests/integration/components/x-form-test.js
@@ -1,0 +1,97 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { fillIn, click, keyEvent, triggerEvent } from 'ember-native-dom-helpers/test-support/helpers';
+
+moduleForComponent('x-form', 'Integration | Component | x-form', {
+  integration: true
+});
+
+const find = (selector) => document.querySelectorAll(`#ember-testing ${selector}`);
+
+test('form inputs exist', function(assert) {
+  this.render(hbs`{{x-form}}`);
+
+  assert.equal(this.$('input[type="text"]').length, 1);
+  assert.equal(this.$('input[type="checkbox"]').length, 1);
+  assert.equal(this.$('button[type="submit"]').length, 1);
+  assert.equal(this.$('textarea').length, 1);
+  assert.equal(this.$('a.terms-show').length, 1);
+  assert.equal(this.$('button.terms-agree').length, 1);
+});
+
+test('can fill in a text input field', function(assert) {
+  this.render(hbs`{{x-form}}`);
+
+  let text = 'yada yada';
+  let selector = 'input[type="text"]';
+  let value = find(selector)[0].value;
+  assert.equal(value, '', 'nothing input yet');
+  fillIn(selector, text);
+
+  value = find(selector)[0].value;
+  assert.equal(value, text, `expected ${value} to be ${text}`);
+});
+
+test('can fill in a textarea field', function(assert) {
+  this.render(hbs`{{x-form}}`);
+
+  let text = 'yada yada';
+  let selector = 'textarea';
+  let value = find(selector)[0].value;
+  assert.equal(value, '', 'nothing input yet');
+  fillIn(selector, text);
+
+  value = find(selector)[0].value;
+  assert.equal(value, text, `expected ${value} to be ${text}`);
+});
+
+test('can click a checkbox', function(assert) {
+  this.render(hbs`{{x-form}}`);
+  let selector = 'input[type="checkbox"]';
+  let el = find(selector)[0];
+  assert.equal(el.checked, false, 'input NOT checked');
+  click(selector);
+
+  el = find(selector)[0];
+  assert.ok(el.checked, 'input checked');
+});
+
+test('can trigger change on a select input', function(assert) {
+  assert.expect(2);
+  this.set('externalAction', (val) => {
+    assert.equal(val, 'blue');
+  });
+
+  this.render(hbs`{{x-form onSelect=(action externalAction)}}`);
+
+  let selector = 'select > option[selected]';
+  find(selector)[0].selected = false;
+  selector = 'select > option[value="blue"]';
+  click(selector);
+  find(selector)[0].selected = true;
+  selector = 'select';
+  // await
+  triggerEvent(selector, 'change');
+  let el = find(selector)[0];
+  assert.equal(el.value, 'blue');
+});
+
+test('can trigger a keyEvent', function(assert) {
+  this.render(hbs`{{x-form}}`);
+
+  let selector = '.message';
+  let el = find(selector)[0];
+  assert.ok(el.innerText === '', 'no message printed yet');
+
+  selector = '.terms-show';
+  click(selector);
+  selector = '.terms-agree';
+  click(selector);
+  selector = 'input[type="text"]';
+  // await
+  keyEvent(selector, 'keyup', 13);
+
+  selector = '.message';
+  el = find(selector)[0];
+  assert.ok(el.innerText !== '', 'message printed after submit');
+});

--- a/tests/integration/components/x-form-test.js
+++ b/tests/integration/components/x-form-test.js
@@ -1,12 +1,10 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { fillIn, click, keyEvent, triggerEvent } from 'ember-native-dom-helpers/test-support/helpers';
+import { find, first, fillIn, click, keyEvent, triggerEvent } from 'ember-native-dom-helpers/test-support/helpers';
 
 moduleForComponent('x-form', 'Integration | Component | x-form', {
   integration: true
 });
-
-const find = (selector) => document.querySelectorAll(`#ember-testing ${selector}`);
 
 test('form inputs exist', function(assert) {
   this.render(hbs`{{x-form}}`);
@@ -24,11 +22,12 @@ test('can fill in a text input field', function(assert) {
 
   let text = 'yada yada';
   let selector = 'input[type="text"]';
-  let value = find(selector)[0].value;
+
+  let value = find(selector).value;
   assert.equal(value, '', 'nothing input yet');
   fillIn(selector, text);
 
-  value = find(selector)[0].value;
+  value = find(selector).value;
   assert.equal(value, text, `expected ${value} to be ${text}`);
 });
 
@@ -37,22 +36,22 @@ test('can fill in a textarea field', function(assert) {
 
   let text = 'yada yada';
   let selector = 'textarea';
-  let value = find(selector)[0].value;
+  let value = find(selector).value;
   assert.equal(value, '', 'nothing input yet');
   fillIn(selector, text);
 
-  value = find(selector)[0].value;
+  value = find(selector).value;
   assert.equal(value, text, `expected ${value} to be ${text}`);
 });
 
 test('can click a checkbox', function(assert) {
   this.render(hbs`{{x-form}}`);
   let selector = 'input[type="checkbox"]';
-  let el = find(selector)[0];
+  let el = find(selector);
   assert.equal(el.checked, false, 'input NOT checked');
   click(selector);
 
-  el = find(selector)[0];
+  el = find(selector);
   assert.ok(el.checked, 'input checked');
 });
 
@@ -65,33 +64,51 @@ test('can trigger change on a select input', function(assert) {
   this.render(hbs`{{x-form onSelect=(action externalAction)}}`);
 
   let selector = 'select > option[selected]';
-  find(selector)[0].selected = false;
+  find(selector).selected = false;
   selector = 'select > option[value="blue"]';
   click(selector);
-  find(selector)[0].selected = true;
+  find(selector).selected = true;
   selector = 'select';
-  // await
   triggerEvent(selector, 'change');
-  let el = find(selector)[0];
+  let el = find(selector);
   assert.equal(el.value, 'blue');
 });
 
-test('can trigger a keyEvent', function(assert) {
+test('can click to submit form', function(assert) {
   this.render(hbs`{{x-form}}`);
 
-  let selector = '.message';
-  let el = find(selector)[0];
+  let el = find('.message');
   assert.ok(el.innerText === '', 'no message printed yet');
 
-  selector = '.terms-show';
-  click(selector);
-  selector = '.terms-agree';
-  click(selector);
-  selector = 'input[type="text"]';
-  // await
-  keyEvent(selector, 'keyup', 13);
+  click('.terms-show');
+  click('.terms-agree');
+  click('button[type="submit"]')
 
-  selector = '.message';
-  el = find(selector)[0];
+  el = find('.message');
   assert.ok(el.innerText !== '', 'message printed after submit');
+});
+
+test('can trigger a keyEvent to submit form', function(assert) {
+  this.render(hbs`{{x-form}}`);
+
+  let el = find('.message');
+  assert.ok(el.innerText === '', 'no message printed yet');
+
+  click('.terms-show');
+  click('button'); // '.terms-agree' is the first button so it will be clicked
+  // not using `click('button[type="submit"]')` instead submit with the enter key;
+  keyEvent('input[type="text"]', 'keyup', 13);
+
+  el = find('.message');
+  assert.ok(el.innerText !== '', 'message printed after submit');
+});
+
+test('can click the first link', function(assert) {
+  this.render(hbs`{{x-form}}`);
+
+  let el = find('section');
+  assert.ok(el.classList.contains('terms-hidden'), 'terms are hidden');
+
+  click(first('a'));
+  assert.ok(!el.classList.contains('terms-hidden'), 'terms are NOT hidden');
 });

--- a/tests/integration/find-test.js
+++ b/tests/integration/find-test.js
@@ -1,0 +1,110 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { find, first } from 'ember-native-dom-helpers/test-support/helpers';
+
+
+moduleForComponent('find', 'Integration | Test Helper | find', {
+  integration: true
+});
+
+test('find helper uses querySelectorAll within test DOM', function(assert) {
+  const selector = 'input[type="text"]';
+  const firstInput = document.querySelectorAll(selector)[0];
+
+  this.render(hbs`
+    <input type="text" />
+  `);
+  let expected = document.querySelectorAll(`#ember-testing ${selector}`)[0];
+  let actual = find(selector);
+
+  assert.strictEqual(actual, expected, 'input found within #ember-testing');
+  assert.notStrictEqual(actual, firstInput, 'test runner input not selected with find');
+});
+
+test('find helper can find using an element as the context to query', function(assert) {
+  this.render(hbs`
+    <select>
+      <option value="">Choose one</option>
+      <option value="0">Zero</option>
+      <option value="1" selected="selected">One</option>
+    </select>
+  `);
+
+  let expected = document.querySelectorAll('#ember-testing select')[0];
+  let actual = find('select');
+  assert.strictEqual(actual, expected, 'select found within #ember-testing');
+
+  expected = document.querySelectorAll('#ember-testing select option[selected]')[0];
+  actual = find('option[selected]', actual); 
+  assert.strictEqual(actual, expected, 'option found within select element');
+});
+
+test('find returns only one element when the resulting node list has one item', function(assert) {
+  this.render(hbs`
+    <ul>
+      <li>One</li>
+      <li>Two</li>
+    </ul>
+  `);
+
+  let expected = document.querySelectorAll('#ember-testing li:last-child')[0];
+  let actual = find('li:last-child');
+  assert.strictEqual(actual, expected, 'li:last-child element found within #ember-testing');
+});
+
+test('find returns the resulting node list if selector matches more than one item', function(assert) {
+  this.render(hbs`
+    <ul>
+      <li>One</li>
+      <li>Two</li>
+    </ul>
+    <ol>
+      <li>A</li>
+      <li>B</li>
+    </ol>
+  `);
+
+  let expected = [
+    document.querySelectorAll('#ember-testing ul li:last-child')[0],
+    document.querySelectorAll('#ember-testing ol li:last-child')[0]
+  ];
+  let actual = find('li:last-child');
+  assert.strictEqual(actual[0], expected[0], 'one li:last-child element found within #ember-testing');
+  assert.strictEqual(actual[1], expected[1], 'two li:last-child elements found within #ember-testing');
+});
+
+test('first helper is like find but returns only an element', function(assert) {
+  this.render(hbs`
+    <ul>
+      <li>One</li>
+      <li>Two</li>
+    </ul>
+    <ol>
+      <li>A</li>
+      <li>B</li>
+    </ol>
+  `);
+
+  let expected = document.querySelectorAll('#ember-testing li:last-child')[0];
+  let actual = first('li:last-child');
+  assert.strictEqual(actual, expected, 'li element found within #ember-testing');
+});
+
+test('if an element is passed to find instead of a selector it is returned', function(assert) {
+  this.render(hbs`
+    <a href="https://emberjs.com">Ember</a>
+  `);
+  let expected = document.querySelector('#ember-testing a');
+  let actual = find(expected);
+  assert.strictEqual(actual, expected, 'element was returned from find');
+});
+
+test('if a node list is passed to find instead of a selector it is returned', function(assert) {
+  this.render(hbs`
+    <a href="https://emberjs.com">Ember</a>
+    <a href="https://ember-cli.com">Ember CLI</a>
+  `);
+  let expected = document.querySelector('#ember-testing a');
+  let actual = find(expected);
+  assert.strictEqual(actual, expected, 'node list was returned from find');
+});

--- a/tests/integration/find-test.js
+++ b/tests/integration/find-test.js
@@ -1,6 +1,8 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { find, first } from 'ember-native-dom-helpers/test-support/helpers';
+import settings from 'ember-native-dom-helpers/test-support/settings';
+import Ember from 'ember';
 
 
 moduleForComponent('find', 'Integration | Test Helper | find', {
@@ -107,4 +109,25 @@ test('if a node list is passed to find instead of a selector it is returned', fu
   let expected = document.querySelector('#ember-testing a');
   let actual = find(expected);
   assert.strictEqual(actual, expected, 'node list was returned from find');
+});
+
+test('with setting for using jquery with the find helper', function(assert) {
+  // Can be used for test suites that have lots of jquery usage
+  settings.useJQueryWrapper = true;
+
+  this.render(hbs`
+    <a href="https://emberjs.com">Ember</a>
+    <a href="https://ember-cli.com">Ember CLI</a>
+  `);
+
+  let expected = Ember.$('#ember-testing a').first();
+  let actual = find('a').first();
+  assert.strictEqual(actual[0], expected[0], 'anchor elment found');
+  assert.ok(actual.jquery, 'element is a jquery instance');
+
+  actual = first('a');
+  assert.strictEqual(actual[0], expected[0], 'first anchor elment found');
+  assert.ok(actual.jquery, 'first element is a jquery instance');
+
+  settings.useJQueryWrapper = false;
 });

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -4,3 +4,9 @@ import {
 } from 'ember-qunit';
 
 setResolver(resolver);
+
+import settings from 'ember-native-dom-helpers/test-support/settings';
+import config from '../config/environment';
+const { APP: { rootElement } } = config;
+
+settings.rootElement = rootElement || settings.rootElement;

--- a/yarn.lock
+++ b/yarn.lock
@@ -574,23 +574,6 @@ broccoli-clean-css@^1.1.0:
     inline-source-map-comment "^1.0.5"
     json-stable-stringify "^1.0.0"
 
-broccoli-concat@^3.0.4:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/broccoli-concat/-/broccoli-concat-3.2.0.tgz#88fb861e732085e92a499e3a62213c1684ba00d5"
-  dependencies:
-    broccoli-kitchen-sink-helpers "^0.3.1"
-    broccoli-plugin "^1.3.0"
-    broccoli-stew "^1.3.3"
-    ensure-posix-path "^1.0.2"
-    fast-sourcemap-concat "^1.0.1"
-    find-index "^1.1.0"
-    fs-extra "^1.0.0"
-    fs-tree-diff "^0.5.6"
-    lodash.merge "^4.3.0"
-    lodash.omit "^4.1.0"
-    lodash.uniq "^4.2.0"
-    walk-sync "^0.3.1"
-
 broccoli-concat@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/broccoli-concat/-/broccoli-concat-3.2.2.tgz#86ffdc52606eb590ba9f6b894c5ec7a016f5b7b9"


### PR DESCRIPTION
Add find helper and use within test helpers

- Support same params as Ember's `find` helper, only not using `$`
- `find` helper uses `document.querySelectorAll` and when only one element is found, simple return that element; otherwise the `NodeList`
- Use app config/enviroment setting for `rootElement` (default is `#ember-testing`) - to query within the test DOM (vs all DOM including test runner HTML)

In order to support a `find` (DOM) query only inside the Ember application's DOM the consuming application's config is used. For now in `tests/test-helper.js` the default value for `#ember-testing` as the `rootElement` can be set per the app's config:

```js
import settings from 'ember-native-dom-helpers/test-support/settings';
import config from '../config/environment';
const { APP: { rootElement } } = config;

settings.rootElement = rootElement || settings.rootElement;
```

Also, since these are test helpers I thought it would be a good idea to include an integration test using them. I added a form component in the dummy app and an integration test that uses these helpers.

The `find` helper acts like it uses jQuery's selector but does not so helper are some affordances:

- If a HTMLElement is passed to find, simply return it
- If a NodeList is passed to find, return it
- If selector only matches one HTMLElement return it
- If selector matches more then one element return the NodeList

For the most part the find helper behaves like the find helper for acceptance tests, except is not using jQuery's selector engine, nor returns a wrapped element or set. Instead native DOM element(s) will be returned. Hence the native `find` helper returns one or a set of elements.

In addition to a `find` helper there is a `first` helper as well. The implementations of the acceptance test helpers only operate on the first item found from a DOM query. So the these test helpers use the `first` helper to select the first matching element.

For test suites that have heavy use of jQuery - a setting affords using `find` which can return a jQuery wrapped set (instead of HTMLElement or NodeList of HTMLElements).

```js
import settings from 'ember-native-dom-helpers/test-support/settings';
settings.useJQueryWrapper = true;
```