### PR TITLE
Fire focus event even when window is not in focus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,16 @@ language: node_js
 node_js:
   - "6"
 
+dist: trusty
 sudo: false
 
-cache:
-  directories:
-    - $HOME/.npm
-    - $HOME/.cache # includes bowers cache
+addons:
+  firefox: latest
+  apt:
+    packages:
+     - google-chrome-stable
+
+cache: yarn
 
 env:
   # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
@@ -26,13 +30,19 @@ matrix:
 
 before_install:
   - npm config set spin false
-  - npm install -g bower phantomjs-prebuilt
+  - npm install -g bower phantomjs-prebuilt yarn
   - bower --version
   - phantomjs --version
+  - yarn --version
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
 
 install:
-  - npm install
-  - bower install
+  - yarn
+
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
 
 script:
   # Usually, it's ok to finish the test scenario without reverting

--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import wait from 'ember-test-helpers/wait';
 
-const { run, $, merge } = Ember;
+const { run, merge } = Ember;
 
 const DEFAULT_EVENT_OPTIONS = { canBubble: true, cancelable: true };
 const KEYBOARD_EVENT_TYPES = ['keydown', 'keypress', 'keyup'];
@@ -9,19 +9,19 @@ const MOUSE_EVENT_TYPES = ['click', 'mousedown', 'mouseup', 'dblclick', 'mouseen
 
 function focus(el) {
   if (!el) { return; }
-  let $el = $(el);
-  if ($el.is(':input, [contenteditable=true]')) {
-    let type = $el.prop('type');
+
+  if (el.tagName === 'INPUT' || el.contentEditable || el.tagName === 'ANCHOR') {
+    let type = el.type;
     if (type !== 'checkbox' && type !== 'radio' && type !== 'hidden') {
       run(null, function() {
         // Firefox does not trigger the `focusin` event if the window
-        // does not have focus. If the document doesn't have focus just
-        // use trigger('focusin') instead.
-
-        if (!document.hasFocus || document.hasFocus()) {
-          el.focus();
+        // does not have focus. If the document does not have focus then
+        // fire `focusin` event as well.
+        if (document.hasFocus && !document.hasFocus()) {
+          fireEvent(el, 'focusin');
+          fireEvent(el, 'focus', null, false); // focus does not bubble
         } else {
-          $el.trigger('focusin');
+          el.focus();
         }
       });
     }
@@ -53,9 +53,9 @@ function fireEvent(element, type, options = {}) {
   element.dispatchEvent(event);
 }
 
-function buildBasicEvent(type, options = {}) {
+function buildBasicEvent(type, options = {}, bubbles = true, cancelable = true) {
   let event = document.createEvent('Events');
-  event.initEvent(type, true, true);
+  event.initEvent(type, bubbles, cancelable);
   merge(event, options);
   return event;
 }

--- a/testem.js
+++ b/testem.js
@@ -3,10 +3,12 @@ module.exports = {
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
   "launch_in_ci": [
-    "PhantomJS"
+    "PhantomJS",
+    "Firefox",
+    "Chrome"
   ],
   "launch_in_dev": [
-    "PhantomJS",
+    "Firefox",
     "Chrome"
   ]
 };

--- a/tests/integration/key-event-test.js
+++ b/tests/integration/key-event-test.js
@@ -34,12 +34,16 @@ test('It can fire keyup events', function(assert) {
 });
 
 test('It can fire keypress events', function(assert) {
-  assert.expect(4);
+  assert.expect(3);
   this.onKeyPress = (e) => {
     assert.ok(true, 'a focus event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
-    assert.equal(e.keyCode, 40, 'The event has the right keyCode');
-    assert.equal(e.which, 40, 'The event has the right which');
+    // event.which is deprecated, favor `keyCode`
+    if (e.keyCode) {
+      assert.equal(e.keyCode, 40, 'The event has the right keyCode');
+    } else {
+      assert.equal(e.which, 40, 'The event has the right which');
+    }
   }
 
   this.render(hbs`<input class="target-element" onkeypress={{onKeyPress}} />`);


### PR DESCRIPTION
- When running tests window may not be in focus, so manually fire focus, otherwise use `el.focus()`
- Remove `$` (jQuery) from helper
- Use real browsers, not just PhantomJS

Fixes #3