### PR TITLE
Remove broccoli-concat from package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "broccoli-concat": "^3.2.2",
     "ember-cli-babel": "^5.1.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Try a build with the dependency for broccoli-concat removed. `yarn upgrade broccoli-concat` added under dependencies in package.json. Also, the yarn.lock ended up with two entries vs 3.2.0 and 3.2.2. Perhpas that is why the builds were failing without this dependency specified. Extra version removed from yarn.lock in 6a15aab

See https://github.com/broccolijs/broccoli-concat/issues/106#issuecomment-281811267