### PR TITLE
Remove settings for optional jquery wrapped find result

### DIFF
--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -119,7 +119,7 @@ function buildKeyboardEvent(type, options = {}) {
   @public
 */
 export function click(selector, options = {}) {
-  let el = unwrapjQueryEl(first(selector));
+  let el = first(selector);
   run(() => fireEvent(el, 'mousedown', options));
   focus(el);
   run(() => fireEvent(el, 'mouseup', options));
@@ -135,7 +135,7 @@ export function click(selector, options = {}) {
   @public
 */
 export function fillIn(selector, text) {
-  let el = unwrapjQueryEl(first(selector));
+  let el = first(selector);
   run(() => focus(el));
   run(() => el.value = text);
   run(() => fireEvent(el, 'input'));
@@ -152,7 +152,7 @@ export function fillIn(selector, text) {
   @public
 */
 export function triggerEvent(selector, type, options) {
-  let el = unwrapjQueryEl(first(selector));
+  let el = first(selector);
   run(() => fireEvent(el, type, options));
   return wait();
 }
@@ -181,19 +181,15 @@ export function keyEvent(selector, type, keyCode) {
   @public
 */
 export function find(selector, contextEl) {
-  let selected;
+  let result;
   if (selector instanceof HTMLElement || selector instanceof NodeList) {
-    selected = selector;
+    result = selector;
   } else if (contextEl instanceof HTMLElement) {
-    selected = contextEl.querySelectorAll(selector);
+    result = contextEl.querySelectorAll(selector);
   } else if (Object.prototype.toString.call(selector) === "[object String]") {
-    selected = document.querySelectorAll(`${settings.rootElement} ${selector}`);
+    result = document.querySelectorAll(`${settings.rootElement} ${selector}`);
   }
-  if (!settings.useJQueryWrapper) {
-    return (selected.length === 1) ? selected[0] : selected;
-  } else {
-    return (selector.jquery /*passed a jQuery obj*/) ? selector : Ember.$(selected);
-  }
+  return (result.length === 1) ? result[0] : result;
 }
 
 
@@ -209,13 +205,5 @@ export function find(selector, contextEl) {
 */
 export function first(selector, contextEl) {
   const el = find(selector, contextEl);
-  if (!settings.useJQueryWrapper) {
-    return (el instanceof NodeList) ? el[0] : el;
-  } else {
-    return el.first();
-  }
-}
-
-function unwrapjQueryEl(el) {
-  return (settings.useJQueryWrapper && el.jquery) ? el[0] : el;
+  return (el instanceof NodeList) ? el[0] : el;
 }

--- a/addon-test-support/settings.js
+++ b/addon-test-support/settings.js
@@ -5,9 +5,8 @@
 */
 class TestSupportSettings {
 
-  constructor(init = { rootElement: '#ember-testing', $: false}) {
+  constructor(init = { rootElement: '#ember-testing' }) {
     this._rootElement = init.rootElement;
-    this._useJQueryWrapper = init.$;
   }
 
   /*
@@ -21,17 +20,6 @@ class TestSupportSettings {
   }
   set rootElement(value) {
     this._rootElement = value;
-  }
-
-  /*
-    @public useJQueryWrapper
-    @type Boolean
-  */
-  get useJQueryWrapper() {
-    return this._useJQueryWrapper;
-  }
-  set useJQueryWrapper(value) {
-    this._useJQueryWrapper = value;
   }
 }
 

--- a/tests/integration/find-test.js
+++ b/tests/integration/find-test.js
@@ -1,8 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { find, first } from 'ember-native-dom-helpers/test-support/helpers';
-import settings from 'ember-native-dom-helpers/test-support/settings';
-import Ember from 'ember';
 
 
 moduleForComponent('find', 'Integration | Test Helper | find', {
@@ -109,25 +107,4 @@ test('if a node list is passed to find instead of a selector it is returned', fu
   let expected = document.querySelector('#ember-testing a');
   let actual = find(expected);
   assert.strictEqual(actual, expected, 'node list was returned from find');
-});
-
-test('with setting for using jquery with the find helper', function(assert) {
-  // Can be used for test suites that have lots of jquery usage
-  settings.useJQueryWrapper = true;
-
-  this.render(hbs`
-    <a href="https://emberjs.com">Ember</a>
-    <a href="https://ember-cli.com">Ember CLI</a>
-  `);
-
-  let expected = Ember.$('#ember-testing a').first();
-  let actual = find('a').first();
-  assert.strictEqual(actual[0], expected[0], 'anchor elment found');
-  assert.ok(actual.jquery, 'element is a jquery instance');
-
-  actual = first('a');
-  assert.strictEqual(actual[0], expected[0], 'first anchor elment found');
-  assert.ok(actual.jquery, 'first element is a jquery instance');
-
-  settings.useJQueryWrapper = false;
 });


### PR DESCRIPTION
This addon is a way to start the gradual migration towards the future "testing unification" RFC setup. That RFC proposes only native DOM.

If a tests needs jQuery, it will be more explicit in the test code for the developer to wrap the find call, e.g. `jQuery(find('a'))`
