### PR TITLE
Find helper results null when query has empty result

### DIFF
--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -177,7 +177,7 @@ export function keyEvent(selector, type, keyCode) {
   @method find
   @param {String|HTMLElement|NodeList} CSS selector to find one or more elements in the test DOM
   @param {HTMLElement} contextEl to query within, query from its contained DOM
-  @return {HTMLElement|NodeList} one element or a (non-live) list of element objects
+  @return {null|HTMLElement|NodeList} null, one element or a (non-live) list of element objects
   @public
 */
 export function find(selector, contextEl) {
@@ -189,7 +189,7 @@ export function find(selector, contextEl) {
   } else if (Object.prototype.toString.call(selector) === "[object String]") {
     result = document.querySelectorAll(`${settings.rootElement} ${selector}`);
   }
-  return (result.length === 1) ? result[0] : result;
+  return (result.length === 0) ? null : (result.length === 1) ? result[0] : result;
 }
 
 

--- a/tests/integration/find-test.js
+++ b/tests/integration/find-test.js
@@ -108,3 +108,12 @@ test('if a node list is passed to find instead of a selector it is returned', fu
   let actual = find(expected);
   assert.strictEqual(actual, expected, 'node list was returned from find');
 });
+
+test('with empty query result, find returns null', function(assert) {
+  this.render(hbs`
+    <div class='hiding'>You can't find me</div>
+  `);
+  let expected = null;
+  let actual = find('.hidden');
+  assert.strictEqual(actual, expected, 'null is returned for an empty query');
+});


### PR DESCRIPTION
Originally the `find` helper returns an empty `NodeList` when the query has an empty result. Alternatively if the query has only a single result, instead of returning the `NodeList` with one `HTMLElement` the `find` helper returns the only result the `HTMLElement`. 

The check for an empty result is `find('.not-present').length === 0`. Since the helper is acting intuitive like either `document.querySelector` or `document.querySelectorAll` the return value should be similar. No result from `querySelector` is `null` and an no results from `querySelectorAll` is an empty `NodeList`. 

Checking for a `null` result when a query is made for one matching element makes sense. The find helper doesn't know that the result should be one or more based on the query. So returning an empty NodeList seems less than ideal. 

Returning `null`, `HTMLElement` or `NodeList[HTMLElement]` is the gist of this PR.

Alternatively we could use two helpers, `find(string) null | HTMLElement` and `findAll(string) NodeList[]` (the node list may be empty when the query has no matching result.

Fixes #13 