### PR TITLE
Use relative imports inside same folder

### DIFF
--- a/addon-test-support/click.js
+++ b/addon-test-support/click.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import { findWithAssert } from 'ember-native-dom-helpers/test-support/find-with-assert';
-import { fireEvent } from 'ember-native-dom-helpers/test-support/fire-event';
-import { focus } from 'ember-native-dom-helpers/test-support/focus';
+import { findWithAssert } from './find-with-assert';
+import { fireEvent } from './fire-event';
+import { focus } from './focus';
 import wait from 'ember-test-helpers/wait';
 
 const { run } = Ember;

--- a/addon-test-support/fill-in.js
+++ b/addon-test-support/fill-in.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import { findWithAssert } from 'ember-native-dom-helpers/test-support/find-with-assert';
-import { focus } from 'ember-native-dom-helpers/test-support/focus';
-import { fireEvent } from 'ember-native-dom-helpers/test-support/fire-event';
+import { findWithAssert } from './find-with-assert';
+import { focus } from './focus';
+import { fireEvent } from './fire-event';
 import wait from 'ember-test-helpers/wait';
 
 const { run } = Ember;

--- a/addon-test-support/find-all.js
+++ b/addon-test-support/find-all.js
@@ -1,4 +1,4 @@
-import settings from 'ember-native-dom-helpers/test-support/settings';
+import settings from './settings';
 
 /*
   The findAll test helper uses `querySelectorAll` to search inside the test

--- a/addon-test-support/find.js
+++ b/addon-test-support/find.js
@@ -1,4 +1,4 @@
-import settings from 'ember-native-dom-helpers/test-support/settings';
+import settings from './settings';
 
 /*
   The find test helper uses `querySelector` to search inside the test

--- a/addon-test-support/focus.js
+++ b/addon-test-support/focus.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import { fireEvent } from 'ember-native-dom-helpers/test-support/fire-event';
+import { fireEvent } from './fire-event';
 import wait from 'ember-test-helpers/wait';
 
 const { run } = Ember;

--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -1,7 +1,7 @@
-export { find } from 'ember-native-dom-helpers/test-support/find';
-export { findAll } from 'ember-native-dom-helpers/test-support/find-all';
-export { findWithAssert } from 'ember-native-dom-helpers/test-support/find-with-assert';
-export { click } from 'ember-native-dom-helpers/test-support/click';
-export { fillIn } from 'ember-native-dom-helpers/test-support/fill-in';
-export { keyEvent } from 'ember-native-dom-helpers/test-support/key-event';
-export { triggerEvent } from 'ember-native-dom-helpers/test-support/trigger-event';
+export { find } from './find';
+export { findAll } from './find-all';
+export { findWithAssert } from './find-with-assert';
+export { click } from './click';
+export { fillIn } from './fill-in';
+export { keyEvent } from './key-event';
+export { triggerEvent } from './trigger-event';

--- a/addon-test-support/key-event.js
+++ b/addon-test-support/key-event.js
@@ -1,4 +1,4 @@
-import { triggerEvent } from 'ember-native-dom-helpers/test-support/trigger-event';
+import { triggerEvent } from './trigger-event';
 
 /*
   @method keyEvent

--- a/addon-test-support/trigger-event.js
+++ b/addon-test-support/trigger-event.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import { findWithAssert } from 'ember-native-dom-helpers/test-support/find-with-assert';
-import { fireEvent } from 'ember-native-dom-helpers/test-support/fire-event';
+import { findWithAssert } from './find-with-assert';
+import { fireEvent } from './fire-event';
 import wait from 'ember-test-helpers/wait';
 
 const { run } = Ember;


### PR DESCRIPTION
It is shorter and if we rename the addon (which is likely) we don’t
need to do anything