### PR TITLE
Added `tap` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,10 @@ assert.equal($(find('.my-class')).attr('aria-owns'), '#id123')
 - `findWithAssert(selector, contextHTMLElement)` (same as `find`, but raises Error if no result)
 - `keyEvent(selector, type, keyCode)` (type being `keydown`, `keyup` or `keypress`)
 - `triggerEvent(selector, type, options)`
+
+## Notes of `tap`
+
+In order for `tap` to work, your browser has to support touch events. Desktop Chrome and Firefox
+have touch events disabled unless the device emulation mode is on.
+In order to enable touch events in your CI, you need to configure testem like the `testem.js`
+file on this repo.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ assert.equal($(find('.my-class')).attr('aria-owns'), '#id123')
 ## Helpers
 
 - `click(selector, eventOptions)`
+- `tap(selector, eventOptions)`
 - `fillIn(selector, text)`
 - `find(selector, contextHTMLElement)` (query for an element in test DOM, `#ember-testing`)
 - `findAll(selector, contextHTMLElement)` (query for elements in test DOM, `#ember-testing`)

--- a/addon-test-support/click.js
+++ b/addon-test-support/click.js
@@ -6,6 +6,16 @@ import wait from 'ember-test-helpers/wait';
 
 const { run } = Ember;
 
+/*
+  @method clickEventSequence
+  @private
+*/
+export function clickEventSequence(el, options) {
+  run(() => fireEvent(el, 'mousedown', options));
+  focus(el);
+  run(() => fireEvent(el, 'mouseup', options));
+  run(() => fireEvent(el, 'click', options));
+}
 
 /*
   @method click
@@ -16,9 +26,6 @@ const { run } = Ember;
 */
 export function click(selector, options = {}) {
   let el = findWithAssert(selector);
-  run(() => fireEvent(el, 'mousedown', options));
-  focus(el);
-  run(() => fireEvent(el, 'mouseup', options));
-  run(() => fireEvent(el, 'click', options));
+  clickEventSequence(el, options);
   return wait();
 }

--- a/addon-test-support/fire-event.js
+++ b/addon-test-support/fire-event.js
@@ -5,12 +5,12 @@ const DEFAULT_EVENT_OPTIONS = { canBubble: true, cancelable: true };
 const KEYBOARD_EVENT_TYPES = ['keydown', 'keypress', 'keyup'];
 const MOUSE_EVENT_TYPES = ['click', 'mousedown', 'mouseup', 'dblclick', 'mouseenter', 'mouseleave', 'mousemove', 'mouseout', 'mouseover'];
 
-
 /*
   @method fireEvent
   @param {HTMLElement} element
   @param {String} type
   @param {Object} (optional) options
+  @return {Event} The dispatched event
   @private
 */
 export function fireEvent(element, type, options = {}) {
@@ -35,6 +35,7 @@ export function fireEvent(element, type, options = {}) {
     event = buildBasicEvent(type, options);
   }
   element.dispatchEvent(event);
+  return event;
 }
 
 /*

--- a/addon-test-support/helpers.js
+++ b/addon-test-support/helpers.js
@@ -2,6 +2,7 @@ export { find } from './find';
 export { findAll } from './find-all';
 export { findWithAssert } from './find-with-assert';
 export { click } from './click';
+export { tap } from './tap';
 export { fillIn } from './fill-in';
 export { keyEvent } from './key-event';
 export { triggerEvent } from './trigger-event';

--- a/addon-test-support/tap.js
+++ b/addon-test-support/tap.js
@@ -1,0 +1,26 @@
+import Ember from 'ember';
+import { findWithAssert } from './find-with-assert';
+import { fireEvent } from './fire-event';
+import { clickEventSequence } from './click';
+import wait from 'ember-test-helpers/wait';
+
+const { run } = Ember;
+
+/*
+  @method tap
+  @param {String} selector
+  @param {Object} options
+  @return {RSVP.Promise}
+  @public
+*/
+export function tap(selector, options = {}) {
+  let el = findWithAssert(selector);
+  let touchstartEv;
+  let touchendEv;
+  run(() => touchstartEv = fireEvent(el, 'touchstart', options));
+  run(() => touchendEv = fireEvent(el, 'touchend', options));
+  if (!touchstartEv.defaultPrevented && !touchendEv.defaultPrevented) {
+    clickEventSequence(el);
+  }
+  return wait();
+}

--- a/firefox_config.js
+++ b/firefox_config.js
@@ -1,0 +1,1 @@
+user_pref("dom.w3c_touch_events.enabled", 1);

--- a/testem.js
+++ b/testem.js
@@ -10,5 +10,10 @@ module.exports = {
   "launch_in_dev": [
     "Firefox",
     "Chrome"
-  ]
+  ],
+  "browser_args": {
+    "Chrome": [
+      "--touch-events"
+    ]
+  }
 };

--- a/testem.js
+++ b/testem.js
@@ -2,6 +2,7 @@
 module.exports = {
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
+  "firefox_user_js": "./firefox_config.js",
   "launch_in_ci": [
     "PhantomJS",
     "Firefox",

--- a/tests/integration/tap-test.js
+++ b/tests/integration/tap-test.js
@@ -1,0 +1,122 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { tap } from 'ember-native-dom-helpers/test-support/helpers';
+
+
+moduleForComponent('tap', 'Integration | Test Helper | tap', {
+  integration: true
+});
+
+// Note: This test will fail in desktop browsers as it doesn't fire
+// touch events unless device emulation mode is enabled.
+test('It fires touchstart, touchend, and then the click sequence(mousedown -> focus -> mouseup -> click) events on the element with the given selector (in that order)', function(assert) {
+  assert.expect(18);
+  let index = 0;
+  this.onTouchStart = (e) => {
+    assert.equal(++index, 1, 'touchstart is fired first');
+    assert.ok(true, 'a touchstart event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+  }
+  this.onTouchEnd = (e) => {
+    assert.equal(++index, 2, 'touchend is fired second');
+    assert.ok(true, 'a touchend event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+  }
+  this.onMouseDown = (e) => {
+    assert.equal(++index, 3, 'mousedown is fired third');
+    assert.ok(true, 'a mousedown event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+  }
+  this.onFocus = (e) => {
+    assert.equal(++index, 4, 'focus is fired forth');
+    assert.ok(true, 'a focus event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+  }
+  this.onMouseUp = (e) => {
+    assert.equal(++index, 5, 'mouseup is fired fifth');
+    assert.ok(true, 'a mouseup event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+  }
+  this.onClick = (e) => {
+    assert.equal(++index, 6, 'click is fired sixth');
+    assert.ok(true, 'a click event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+  }
+
+  this.render(hbs`
+    <input class="target-element"
+      ontouchstart={{onTouchStart}}
+      ontouchend={{onTouchEnd}}
+      onmouseup={{onMouseUp}}
+      onfocus={{onFocus}}
+      onclick={{onClick}}
+      onmousedown={{onMouseDown}} />
+  `);
+
+  tap('.target-element');
+});
+
+test('It the touchstart event is defaultPrevented, the focus and mouse events are not fired', function(assert) {
+  assert.expect(6);
+  let index = 0;
+  this.onTouchStart = (e) => {
+    assert.equal(++index, 1, 'touchstart is fired first');
+    assert.ok(true, 'a touchstart event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+    e.preventDefault();
+  }
+  this.onTouchEnd = (e) => {
+    assert.equal(++index, 2, 'touchend is fired second');
+    assert.ok(true, 'a touchend event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+  }
+  this.onMouseDown = () => assert.ok(false, 'mousedown should not be fired');
+  this.onFocus = () => assert.ok(false, 'focus should not be fired');
+  this.onMouseUp = () => assert.ok(false, 'mouseup should not be fired');
+  this.onClick = () => assert.ok(false, 'click should not be fired');
+
+  this.render(hbs`
+    <input class="target-element"
+      ontouchstart={{onTouchStart}}
+      ontouchend={{onTouchEnd}}
+      onmouseup={{onMouseUp}}
+      onfocus={{onFocus}}
+      onclick={{onClick}}
+      onmousedown={{onMouseDown}} />
+  `);
+
+  tap('.target-element');
+});
+
+
+test('It the touchend event is defaultPrevented, the focus and mouse events are not fired', function(assert) {
+  assert.expect(6);
+  let index = 0;
+  this.onTouchStart = (e) => {
+    assert.equal(++index, 1, 'touchstart is fired first');
+    assert.ok(true, 'a touchstart event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+  }
+  this.onTouchEnd = (e) => {
+    assert.equal(++index, 2, 'touchend is fired second');
+    assert.ok(true, 'a touchend event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+    e.preventDefault();
+  }
+  this.onMouseDown = () => assert.ok(false, 'mousedown should not be fired');
+  this.onFocus = () => assert.ok(false, 'focus should not be fired');
+  this.onMouseUp = () => assert.ok(false, 'mouseup should not be fired');
+  this.onClick = () => assert.ok(false, 'click should not be fired');
+
+  this.render(hbs`
+    <input class="target-element"
+      ontouchstart={{onTouchStart}}
+      ontouchend={{onTouchEnd}}
+      onmouseup={{onMouseUp}}
+      onfocus={{onFocus}}
+      onclick={{onClick}}
+      onmousedown={{onMouseDown}} />
+  `);
+
+  tap('.target-element');
+});


### PR DESCRIPTION
It simulates the usual `tap` interaction on touch devices.
The logic of events is:

- Fire `touchstart`
- Fire `touchend`
- If none of the previous was defaultPrevented, fire a click secuence
  (mousedown -> focus -> mouseup -> click)