### PR TITLE
Add ember-suave and use yarn upgrade

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,10 +4,14 @@ module.exports = {
     ecmaVersion: 6,
     sourceType: 'module'
   },
-  extends: 'eslint:recommended',
+  extends: [
+    'eslint:recommended',
+    'plugin:ember-suave/recommended'
+  ],
   env: {
     browser: true
   },
   rules: {
+    'ember-suave/no-direct-property-access': 0
   }
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,16 +30,16 @@ matrix:
 
 before_install:
   - npm config set spin false
-  - npm install -g bower phantomjs-prebuilt
-  - bower --version
-  - phantomjs --version
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
-  - yarn --version
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
+  - yarn global add bower phantomjs-prebuilt
+  - bower --version
+  - phantomjs --version
+  - yarn --version
 
 install:
-  - yarn
+  - yarn upgrade
 
 before_script:
   - "export DISPLAY=:99.0"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
     "ember-source": "^2.12.0-beta.1",
+    "eslint-plugin-ember-suave": "^1.0.0",
     "loader.js": "^4.1.0"
   },
   "engines": {

--- a/tests/dummy/app/components/x-form.js
+++ b/tests/dummy/app/components/x-form.js
@@ -27,7 +27,7 @@ export default Ember.Component.extend({
       this.get('onSelect')(evt.target.value);
     },
     submit() {
-      this.submit()
+      this.submit();
     }
   },
 

--- a/tests/integration/click-test.js
+++ b/tests/integration/click-test.js
@@ -2,7 +2,6 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { click } from 'ember-native-dom-helpers/test-support/helpers';
 
-
 moduleForComponent('click', 'Integration | Test Helper | click', {
   integration: true
 });
@@ -14,22 +13,22 @@ test('It fires mousedown, focus, mouseup and click events on the element with th
     assert.equal(++index, 1, 'mousedown is fired first');
     assert.ok(true, 'a mousedown event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
-  }
+  };
   this.onFocus = (e) => {
     assert.equal(++index, 2, 'focus is fired second');
     assert.ok(true, 'a focus event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
-  }
+  };
   this.onMouseUp = (e) => {
     assert.equal(++index, 3, 'mouseup is fired third');
     assert.ok(true, 'a mouseup event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
-  }
+  };
   this.onClick = (e) => {
     assert.equal(++index, 4, 'click is fired third');
     assert.ok(true, 'a click event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
-  }
+  };
 
   this.render(hbs`
     <input class="target-element"

--- a/tests/integration/components/x-form-test.js
+++ b/tests/integration/components/x-form-test.js
@@ -24,7 +24,7 @@ test('can fill in a text input field', function(assert) {
   let text = 'yada yada';
   let selector = 'input[type="text"]';
 
-  let value = find(selector).value;
+  let { value } = find(selector);
   assert.equal(value, '', 'nothing input yet');
   fillIn(selector, text);
 
@@ -37,7 +37,7 @@ test('can fill in a textarea field', function(assert) {
 
   let text = 'yada yada';
   let selector = 'textarea';
-  let value = find(selector).value;
+  let { value } = find(selector);
   assert.equal(value, '', 'nothing input yet');
   fillIn(selector, text);
 
@@ -83,7 +83,7 @@ test('can click to submit form', function(assert) {
 
   click('.terms-show');
   click('.terms-agree');
-  click('button[type="submit"]')
+  click('button[type="submit"]');
 
   el = find('.message');
   assert.ok(el.innerText !== '', 'message printed after submit');

--- a/tests/integration/fill-in-test.js
+++ b/tests/integration/fill-in-test.js
@@ -2,7 +2,6 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { fillIn } from 'ember-native-dom-helpers/test-support/helpers';
 
-
 moduleForComponent('fillIn', 'Integration | Test Helper | fillIn', {
   integration: true
 });
@@ -16,19 +15,19 @@ test('It fires a focus, updates the value, fires input and fires change on the e
     assert.ok(true, 'a focus event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
     assert.equal(e.target.value, 'original value');
-  }
+  };
   this.onInput = (e) => {
     assert.equal(++index, 2, 'input is fired second');
     assert.ok(true, 'a input event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
     assert.equal(e.target.value, 'new value');
-  }
+  };
   this.onChange = (e) => {
     assert.equal(++index, 3, 'change is fired third');
     assert.ok(true, 'a change event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
     assert.equal(e.target.value, 'new value');
-  }
+  };
 
   this.render(hbs`
     <input class="target-element"

--- a/tests/integration/find-all-test.js
+++ b/tests/integration/find-all-test.js
@@ -2,7 +2,6 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { findAll } from 'ember-native-dom-helpers/test-support/helpers';
 
-
 moduleForComponent('find', 'Integration | Test Helper | findAll', {
   integration: true
 });
@@ -19,8 +18,8 @@ test('with empty query result, findAll resturns empty NodeList', function(assert
 });
 
 test('findAll helper uses querySelectorAll within test DOM', function(assert) {
-  const selector = 'input[type="text"]';
-  const firstInput = document.querySelector(selector);
+  let selector = 'input[type="text"]';
+  let firstInput = document.querySelector(selector);
 
   this.render(hbs`
     <input type="text" />

--- a/tests/integration/find-test.js
+++ b/tests/integration/find-test.js
@@ -2,7 +2,6 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { find } from 'ember-native-dom-helpers/test-support/helpers';
 
-
 moduleForComponent('find', 'Integration | Test Helper | find', {
   integration: true
 });
@@ -17,8 +16,8 @@ test('with empty query result, find returns null', function(assert) {
 });
 
 test('find helper uses querySelector within test DOM', function(assert) {
-  const selector = 'input[type="text"]';
-  const firstInput = document.querySelector(selector);
+  let selector = 'input[type="text"]';
+  let firstInput = document.querySelector(selector);
 
   this.render(hbs`
     <input type="text" />
@@ -57,6 +56,6 @@ test('find helper can use (optional) element as the context to query', function(
   assert.strictEqual(actual, expected, 'select found within #ember-testing');
 
   expected = document.querySelector('#ember-testing select option[selected]');
-  actual = find('option[selected]', actual); 
+  actual = find('option[selected]', actual);
   assert.strictEqual(actual, expected, 'option found within select element');
 });

--- a/tests/integration/find-with-assert-test.js
+++ b/tests/integration/find-with-assert-test.js
@@ -2,7 +2,6 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { findWithAssert } from 'ember-native-dom-helpers/test-support/helpers';
 
-
 moduleForComponent('find', 'Integration | Test Helper | findWithAssert', {
   integration: true
 });
@@ -12,12 +11,12 @@ test('with empty query result, findWithAssert raises an error', function(assert)
     <div class='hiding'>You can't find me</div>
   `);
   assert.throws(() => {
-    findWithAssert('.hidden'); 
+    findWithAssert('.hidden');
   });
 });
 
 test('with a query result, findWithAssert helper is the same as find helper', function(assert) {
-  const selector = 'input[type="text"]';
+  let selector = 'input[type="text"]';
 
   this.render(hbs`
     <input type="text" />

--- a/tests/integration/key-event-test.js
+++ b/tests/integration/key-event-test.js
@@ -2,7 +2,6 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { keyEvent } from 'ember-native-dom-helpers/test-support/helpers';
 
-
 moduleForComponent('keyEvent', 'Integration | Test Helper | keyEvent', {
   integration: true
 });
@@ -14,7 +13,7 @@ test('It can fire keydown events', function(assert) {
     assert.ok(e instanceof window.Event, 'It receives a native event');
     assert.equal(e.keyCode, 40, 'The event has the right keyCode');
     assert.equal(e.which, 40, 'The event has the right which');
-  }
+  };
 
   this.render(hbs`<input class="target-element" onkeydown={{onKeyDown}} />`);
   keyEvent('.target-element', 'keydown', 40);
@@ -27,7 +26,7 @@ test('It can fire keyup events', function(assert) {
     assert.ok(e instanceof window.Event, 'It receives a native event');
     assert.equal(e.keyCode, 40, 'The event has the right keyCode');
     assert.equal(e.which, 40, 'The event has the right which');
-  }
+  };
 
   this.render(hbs`<input class="target-element" onkeyup={{onKeyUp}} />`);
   keyEvent('.target-element', 'keyup', 40);
@@ -46,7 +45,7 @@ test('It can fire keypress events', function(assert) {
       assert.equal(e.keyCode, 40, 'The event has the right keyCode');
     }
     done();
-  }
+  };
 
   this.render(hbs`<input class="target-element" onkeypress={{onKeyPress}} />`);
   keyEvent('.target-element', 'keypress', 40);

--- a/tests/integration/tap-test.js
+++ b/tests/integration/tap-test.js
@@ -2,7 +2,6 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { tap } from 'ember-native-dom-helpers/test-support/helpers';
 
-
 moduleForComponent('tap', 'Integration | Test Helper | tap', {
   integration: true
 });
@@ -16,32 +15,32 @@ test('It fires touchstart, touchend, and then the click sequence(mousedown -> fo
     assert.equal(++index, 1, 'touchstart is fired first');
     assert.ok(true, 'a touchstart event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
-  }
+  };
   this.onTouchEnd = (e) => {
     assert.equal(++index, 2, 'touchend is fired second');
     assert.ok(true, 'a touchend event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
-  }
+  };
   this.onMouseDown = (e) => {
     assert.equal(++index, 3, 'mousedown is fired third');
     assert.ok(true, 'a mousedown event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
-  }
+  };
   this.onFocus = (e) => {
     assert.equal(++index, 4, 'focus is fired forth');
     assert.ok(true, 'a focus event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
-  }
+  };
   this.onMouseUp = (e) => {
     assert.equal(++index, 5, 'mouseup is fired fifth');
     assert.ok(true, 'a mouseup event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
-  }
+  };
   this.onClick = (e) => {
     assert.equal(++index, 6, 'click is fired sixth');
     assert.ok(true, 'a click event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
-  }
+  };
 
   this.render(hbs`
     <input class="target-element"
@@ -64,12 +63,12 @@ test('It the touchstart event is defaultPrevented, the focus and mouse events ar
     assert.ok(true, 'a touchstart event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
     e.preventDefault();
-  }
+  };
   this.onTouchEnd = (e) => {
     assert.equal(++index, 2, 'touchend is fired second');
     assert.ok(true, 'a touchend event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
-  }
+  };
   this.onMouseDown = () => assert.ok(false, 'mousedown should not be fired');
   this.onFocus = () => assert.ok(false, 'focus should not be fired');
   this.onMouseUp = () => assert.ok(false, 'mouseup should not be fired');
@@ -88,7 +87,6 @@ test('It the touchstart event is defaultPrevented, the focus and mouse events ar
   tap('.target-element');
 });
 
-
 test('It the touchend event is defaultPrevented, the focus and mouse events are not fired', function(assert) {
   assert.expect(6);
   let index = 0;
@@ -96,13 +94,13 @@ test('It the touchend event is defaultPrevented, the focus and mouse events are 
     assert.equal(++index, 1, 'touchstart is fired first');
     assert.ok(true, 'a touchstart event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
-  }
+  };
   this.onTouchEnd = (e) => {
     assert.equal(++index, 2, 'touchend is fired second');
     assert.ok(true, 'a touchend event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
     e.preventDefault();
-  }
+  };
   this.onMouseDown = () => assert.ok(false, 'mousedown should not be fired');
   this.onFocus = () => assert.ok(false, 'focus should not be fired');
   this.onMouseUp = () => assert.ok(false, 'mouseup should not be fired');

--- a/tests/integration/trigger-event-test.js
+++ b/tests/integration/trigger-event-test.js
@@ -2,7 +2,6 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { triggerEvent } from 'ember-native-dom-helpers/test-support/helpers';
 
-
 moduleForComponent('triggerEvent', 'Integration | Test Helper | triggerEvent', {
   integration: true
 });
@@ -13,7 +12,7 @@ test('It fires events of the given type, no questions asked', function(assert) {
   this.onMouseEnter = (e) => {
     assert.ok(true, 'a focus event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
-  }
+  };
 
   this.render(hbs`<input class="target-element" onmouseenter={{onMouseEnter}} />`);
   triggerEvent('.target-element', 'mouseenter');

--- a/yarn.lock
+++ b/yarn.lock
@@ -574,7 +574,7 @@ broccoli-clean-css@^1.1.0:
     inline-source-map-comment "^1.0.5"
     json-stable-stringify "^1.0.0"
 
-broccoli-concat@^3.2.2:
+broccoli-concat@^3.0.4:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/broccoli-concat/-/broccoli-concat-3.2.2.tgz#86ffdc52606eb590ba9f6b894c5ec7a016f5b7b9"
   dependencies:
@@ -1835,6 +1835,12 @@ escope@^3.6.0:
     es6-weak-map "^2.0.1"
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
+
+eslint-plugin-ember-suave@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ember-suave/-/eslint-plugin-ember-suave-1.0.0.tgz#ea7d232a126562dcd8b1ee3aa2700ac3b626e514"
+  dependencies:
+    requireindex "~1.1.0"
 
 eslint@^3.0.0:
   version "3.15.0"
@@ -4334,6 +4340,10 @@ require-uncached@^1.0.2:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
 
 requires-port@1.x.x:
   version "1.0.0"


### PR DESCRIPTION
`yarn upgrade` can help us catch errors due to updates in transitive dependencies
Also bower and phantom are installed using yarn instead of npm, because we can.