### PR TITLE
Add test harness support for testing without jQuery.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,13 @@ cache: yarn
 
 env:
   # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
+  - EMBER_TRY_SCENARIO=ember-default
+  - EMBER_TRY_SCENARIO=no-jquery
   - EMBER_TRY_SCENARIO=ember-lts-2.4
   - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
-  - EMBER_TRY_SCENARIO=ember-default
 
 matrix:
   fast_finish: true

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -86,6 +86,14 @@ module.exports = {
       npm: {
         devDependencies: {}
       }
+    },
+    {
+      name: 'no-jquery',
+      npm: {
+        devDependencies: {
+          'ember-native-dom-event-dispatcher': '^0.5.4'
+        }
+      }
     }
   ]
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -2,7 +2,14 @@
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
-  var app = new EmberAddon(defaults);
+  let project = defaults.project;
+  let options = {};
+
+  if (project.findAddonByName('ember-native-dom-event-dispatcher')) {
+    options.vendorFiles = { 'jquery.js': null };
+  }
+
+  let app = new EmberAddon(defaults, options);
 
   /*
     This build file specifies the options for the dummy test app of this


### PR DESCRIPTION
* Add new ember-try scenario for `no-jquery`
* Add new scenario to `.travis.yml` (moving `default` and `no-jquery`
  first in the matrix)
* Update `ember-cli-build.js` to properly disable using `jQuery` when
  running under the correct ember-try scenario.