### PR TITLE
Use latest-esr instead of latest.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ dist: trusty
 sudo: false
 
 addons:
-  firefox: latest
+  firefox: latest-esr
   apt:
     packages:
      - google-chrome-stable


### PR DESCRIPTION
latest is currently having issues, so downgrade to latest-esr for now.


Info from https://docs.travis-ci.com/user/firefox/.