### PR TITLE
Blur before focus (when document has focus)

### DIFF
--- a/addon-test-support/focus.js
+++ b/addon-test-support/focus.js
@@ -23,6 +23,7 @@ export function focus(el) {
           fireEvent(el, 'focusin');
           fireEvent(el, 'focus', null, false); // focus does not bubble
         } else {
+          document.activeElement.blur();
           el.focus();
         }
       });

--- a/addon-test-support/focus.js
+++ b/addon-test-support/focus.js
@@ -23,7 +23,6 @@ export function focus(el) {
           fireEvent(el, 'focusin');
           fireEvent(el, 'focus', null, false); // focus does not bubble
         } else {
-          document.activeElement.blur();
           el.focus();
         }
       });

--- a/testem.js
+++ b/testem.js
@@ -4,7 +4,6 @@ module.exports = {
   "disable_watching": true,
   "firefox_user_js": "./firefox_config.js",
   "launch_in_ci": [
-    "PhantomJS",
     "Firefox",
     "Chrome"
   ],

--- a/tests/integration/focus-test.js
+++ b/tests/integration/focus-test.js
@@ -18,8 +18,8 @@ test('It accepts an HTMLElement as first argument', function(assert) {
 });
 
 test('It blurs the focused input before firing focus event on another one', function(assert) {
-  const docIsFocused = document.hasFocus && document.hasFocus();
-  const assertions = docIsFocused ? 8 : 4;
+  let docIsFocused = document.hasFocus && document.hasFocus();
+  let assertions = docIsFocused ? 8 : 4;
   assert.expect(assertions);
 
   let index = 0;

--- a/tests/integration/focus-test.js
+++ b/tests/integration/focus-test.js
@@ -24,13 +24,13 @@ test('It blurs the focused input before firing focus event on another one', func
 
   let index = 0;
   this.onBlur = (e) => {
-    assert.equal(++index, 1, 'blur is fired first');
+    assert.equal(++index, 1, 'blur is fired before focus');
     assert.ok(true, 'a blur event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
     assert.equal(e.target.value, 'a');
   };
   this.onFocus = (e) => {
-    assert.equal(++index, docIsFocused ? 2 : 1, 'focus is fired after blur');
+    assert.equal(++index, docIsFocused ? 2 : 1, 'focus is fired');
     assert.ok(true, 'a focus event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
     assert.equal(e.target.value, 'b');

--- a/tests/integration/focus-test.js
+++ b/tests/integration/focus-test.js
@@ -18,7 +18,10 @@ test('It accepts an HTMLElement as first argument', function(assert) {
 });
 
 test('It blurs the focused input before firing focus event on another one', function(assert) {
-  assert.expect(8);
+  const docIsFocused = document.hasFocus && document.hasFocus();
+  const assertions = docIsFocused ? 8 : 4;
+  assert.expect(assertions);
+
   let index = 0;
   this.onBlur = (e) => {
     assert.equal(++index, 1, 'blur is fired first');
@@ -27,7 +30,7 @@ test('It blurs the focused input before firing focus event on another one', func
     assert.equal(e.target.value, 'a');
   };
   this.onFocus = (e) => {
-    assert.equal(++index, 2, 'focus is fired first');
+    assert.equal(++index, docIsFocused ? 2 : 1, 'focus is fired after blur');
     assert.ok(true, 'a focus event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
     assert.equal(e.target.value, 'b');
@@ -37,9 +40,7 @@ test('It blurs the focused input before firing focus event on another one', func
     <input class="other-element" onblur={{onBlur}} value="a" />
     <input class="target-element" onfocus={{onFocus}} value="b" />
   `);
-  let el = document.querySelector('.other-element');
-  focus(el);
+  document.querySelector('.other-element').focus();
 
-  el = document.querySelector('.target-element');
-  focus(el);
+  focus(document.querySelector('.target-element'));
 });

--- a/tests/integration/focus-test.js
+++ b/tests/integration/focus-test.js
@@ -1,0 +1,45 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { focus } from 'ember-native-dom-helpers/test-support/focus';
+
+moduleForComponent('focus', 'Integration | Test Helper | focus', {
+  integration: true
+});
+
+test('It accepts an HTMLElement as first argument', function(assert) {
+  assert.expect(2);
+  this.onFocus = (e) => {
+    assert.ok(true, 'a focus event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+  };
+
+  this.render(hbs`<input class="target-element" onfocus={{onFocus}} />`);
+  focus(document.querySelector('.target-element'));
+});
+
+test('It blurs the focused input before firing focus event on another one', function(assert) {
+  assert.expect(8);
+  let index = 0;
+  this.onBlur = (e) => {
+    assert.equal(++index, 1, 'blur is fired first');
+    assert.ok(true, 'a blur event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+    assert.equal(e.target.value, 'a');
+  };
+  this.onFocus = (e) => {
+    assert.equal(++index, 2, 'focus is fired first');
+    assert.ok(true, 'a focus event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+    assert.equal(e.target.value, 'b');
+  };
+
+  this.render(hbs`
+    <input class="other-element" onblur={{onBlur}} value="a" />
+    <input class="target-element" onfocus={{onFocus}} value="b" />
+  `);
+  let el = document.querySelector('.other-element');
+  focus(el);
+
+  el = document.querySelector('.target-element');
+  focus(el);
+});


### PR DESCRIPTION
FIxes #31

Well sort of fixes it. When we test in CI or during development without the browser focused `document.focus()` is not used, and there is no way to know what a test focused on last since there is no `document.activeElement`.

Adds new tests to show that when the browser window has focus a blur event is fired naturally as a result of a call to `document.focus()` in the focus helper.

Remove use of PhantomJS in CI, no need only has issues with focus/blur behaviors which aren't helpful.