### PR TITLE
Implement treeForAddonTestSupport to override shifting behavior.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ when using only standard DOM APIs (i.e. without jQuery).
 ### Integration tests
 
 ```js
-import { click, fillIn, find, findAll, keyEvent, triggerEvent } from 'ember-native-dom-helpers/test-support/helpers';
+import { click, fillIn, find, findAll, keyEvent, triggerEvent } from 'ember-native-dom-helpers';
 
 moduleForComponent('my-component', 'Integration | Component | my-component', {
   integration: true
@@ -59,7 +59,7 @@ However now this helper can be replace by the `async`/`await` syntax in ES2017 y
 easier to read tests:
 
 ```js
-import { visit, click, find, fillIn } from 'ember-native-dom-helpers/test-support/helpers';
+import { visit, click, find, fillIn } from 'ember-native-dom-helpers';
 
 moduleForAcceptance('Acceptance | Sign up');
 
@@ -115,7 +115,7 @@ The main advantages are:
 - To use a different value from your `config/environment.js` settings, add to `tests/test-helper.js`…
 
 ```js
-import settings from 'ember-native-dom-helpers/test-support/settings';
+import { settings } from 'ember-native-dom-helpers';
 import config from '../config/environment';
 const { APP: { rootElement } } = config;
 
@@ -144,7 +144,7 @@ Now however thanks to explicit usage of promises and the `waitUntil` helper you 
 perform assertions on unsettled states:
 
 ```js
-import { visit, click, find, fillIn, waitUntil } from 'ember-native-dom-helpers/test-support/helpers';
+import { visit, click, find, fillIn, waitUntil } from 'ember-native-dom-helpers';
 
 moduleForAcceptance('Acceptance | Sign up');
 

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -8,3 +8,4 @@ export { keyEvent } from './key-event';
 export { triggerEvent } from './trigger-event';
 export { visit } from './visit';
 export { waitUntil } from './wait-until';
+export { default as settings } from './settings';

--- a/addon-test-support/test-support/helpers.js
+++ b/addon-test-support/test-support/helpers.js
@@ -1,3 +1,11 @@
+import Ember from 'ember';
+
+Ember.deprecate(
+  `Update imports for ember-native-dom-helpers to use:\n \`import { click, fillIn } from 'ember-native-dom-helpers';`,
+  false,
+  { id: 'ember-native-dom-helpers.test-support.helpers', until: '0.4.0' }
+);
+
 export { find } from '../find';
 export { findAll } from '../find-all';
 export { findWithAssert } from '../find-with-assert';

--- a/addon-test-support/test-support/helpers.js
+++ b/addon-test-support/test-support/helpers.js
@@ -1,0 +1,10 @@
+export { find } from '../find';
+export { findAll } from '../find-all';
+export { findWithAssert } from '../find-with-assert';
+export { click } from '../click';
+export { tap } from '../tap';
+export { fillIn } from '../fill-in';
+export { keyEvent } from '../key-event';
+export { triggerEvent } from '../trigger-event';
+export { visit } from '../visit';
+export { waitUntil } from '../wait-until';

--- a/index.js
+++ b/index.js
@@ -2,5 +2,23 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-native-dom-helpers'
+  name: 'ember-native-dom-helpers',
+
+  treeForAddonTestSupport(tree) {
+    // intentionally not calling _super here
+    // so that can have our `import`'s be
+    // import { click, fillIn } from 'ember-native-dom-helpers';
+
+    const Funnel = require('broccoli-funnel');
+
+    let namespacedTree = new Funnel(tree, {
+      srcDir: '/',
+      destDir: `/${this.moduleName()}`,
+      annotation: `Addon#treeForTestSupport (${this.name})`,
+    });
+
+    return this.preprocessJs(namespacedTree, '/', this.name, {
+      registry: this.registry,
+    });
+  }
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
+    "broccoli-funnel": "^1.1.0",
     "ember-cli-babel": "^6.0.0-beta.9"
   },
   "devDependencies": {
@@ -44,8 +45,8 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-maybe-import-regenerator": "^0.1.5",
     "ember-load-initializers": "^0.6.0",
+    "ember-maybe-import-regenerator": "^0.1.5",
     "ember-resolver": "^3.0.0",
     "ember-source": "~2.12.0",
     "eslint-plugin-ember-suave": "^1.0.0",

--- a/tests/acceptance/usage-in-acceptance-test.js
+++ b/tests/acceptance/usage-in-acceptance-test.js
@@ -1,6 +1,6 @@
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
-import { visit, click, find, fillIn, waitUntil } from 'ember-native-dom-helpers/test-support/helpers';
+import { visit, click, find, fillIn, waitUntil } from 'ember-native-dom-helpers';
 
 moduleForAcceptance('Acceptance | usage in acceptance', {
   beforeEach() {

--- a/tests/integration/click-test.js
+++ b/tests/integration/click-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { click } from 'ember-native-dom-helpers/test-support/helpers';
+import { click } from 'ember-native-dom-helpers';
 
 moduleForComponent('click', 'Integration | Test Helper | click', {
   integration: true

--- a/tests/integration/components/x-form-test.js
+++ b/tests/integration/components/x-form-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { find, findAll, fillIn, click, keyEvent, triggerEvent } from 'ember-native-dom-helpers/test-support/helpers';
+import { find, findAll, fillIn, click, keyEvent, triggerEvent } from 'ember-native-dom-helpers';
 
 moduleForComponent('x-form', 'Integration | Component | x-form', {
   integration: true

--- a/tests/integration/fill-in-test.js
+++ b/tests/integration/fill-in-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { fillIn } from 'ember-native-dom-helpers/test-support/helpers';
+import { fillIn } from 'ember-native-dom-helpers';
 
 moduleForComponent('fillIn', 'Integration | Test Helper | fillIn', {
   integration: true

--- a/tests/integration/find-all-test.js
+++ b/tests/integration/find-all-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { findAll } from 'ember-native-dom-helpers/test-support/helpers';
+import { findAll } from 'ember-native-dom-helpers';
 
 moduleForComponent('find', 'Integration | Test Helper | findAll', {
   integration: true

--- a/tests/integration/find-test.js
+++ b/tests/integration/find-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { find } from 'ember-native-dom-helpers/test-support/helpers';
+import { find } from 'ember-native-dom-helpers';
 
 moduleForComponent('find', 'Integration | Test Helper | find', {
   integration: true

--- a/tests/integration/find-with-assert-test.js
+++ b/tests/integration/find-with-assert-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { findWithAssert } from 'ember-native-dom-helpers/test-support/helpers';
+import { findWithAssert } from 'ember-native-dom-helpers';
 
 moduleForComponent('find', 'Integration | Test Helper | findWithAssert', {
   integration: true

--- a/tests/integration/focus-test.js
+++ b/tests/integration/focus-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { focus } from 'ember-native-dom-helpers/test-support/focus';
+import { focus } from 'ember-native-dom-helpers/focus';
 
 moduleForComponent('focus', 'Integration | Test Helper | focus', {
   integration: true

--- a/tests/integration/key-event-test.js
+++ b/tests/integration/key-event-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { keyEvent } from 'ember-native-dom-helpers/test-support/helpers';
+import { keyEvent } from 'ember-native-dom-helpers';
 
 moduleForComponent('keyEvent', 'Integration | Test Helper | keyEvent', {
   integration: true

--- a/tests/integration/tap-test.js
+++ b/tests/integration/tap-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { tap } from 'ember-native-dom-helpers/test-support/helpers';
+import { tap } from 'ember-native-dom-helpers';
 
 moduleForComponent('tap', 'Integration | Test Helper | tap', {
   integration: true

--- a/tests/integration/trigger-event-test.js
+++ b/tests/integration/trigger-event-test.js
@@ -1,6 +1,6 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { triggerEvent } from 'ember-native-dom-helpers/test-support/helpers';
+import { triggerEvent } from 'ember-native-dom-helpers';
 
 moduleForComponent('triggerEvent', 'Integration | Test Helper | triggerEvent', {
   integration: true

--- a/tests/integration/visit.js
+++ b/tests/integration/visit.js
@@ -1,5 +1,5 @@
 import { moduleForComponent, test } from 'ember-qunit';
-import { visit } from 'ember-native-dom-helpers/test-support/helpers';
+import { visit } from 'ember-native-dom-helpers';
 
 moduleForComponent('fillIn', 'Integration | Test Helper | visit', {
   integration: true

--- a/tests/integration/wait-until-test.js
+++ b/tests/integration/wait-until-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
-import { waitUntil } from 'ember-native-dom-helpers/test-support/helpers';
+import { waitUntil } from 'ember-native-dom-helpers';
 const { run } = Ember;
 
 moduleForComponent('wait-until', 'Integration | Test Helper | waitUntil', {

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -5,7 +5,7 @@ import {
 
 setResolver(resolver);
 
-import settings from 'ember-native-dom-helpers/test-support/settings';
+import { settings } from 'ember-native-dom-helpers';
 import config from '../config/environment';
 const { APP: { rootElement } } = config;
 


### PR DESCRIPTION
Leads to nicer imports:

```js
// new 
import { click, fillIn } from 'ember-native-dom-helpers';

// old 
import { click, fillIn } from 'ember-native-dom-helpers/test-support/helpers';
```

The  `ember-native-dom-helpers/test-support/helpers` module still functions properly, it just emits a deprecation that that module path is deprecated.