### PR TITLE
Make `focus` helper public

### DIFF
--- a/addon-test-support/focus.js
+++ b/addon-test-support/focus.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import getElementWithAssert from './-private/get-element-with-assert';
 import { fireEvent } from './fire-event';
 import wait from 'ember-test-helpers/wait';
 
@@ -6,11 +7,12 @@ const { run } = Ember;
 
 /*
   @method focus
-  @param {HTMLElement} el
-  @private
+  @param {String|HTMLElement} selector
+  @public
 */
-export function focus(el) {
-  if (!el) { return; }
+export function focus(selector) {
+  if (!selector) { return; }
+  let el = getElementWithAssert(selector);
 
   if (el.tagName === 'INPUT' || el.contentEditable || el.tagName === 'A') {
     let type = el.type;

--- a/tests/integration/focus-test.js
+++ b/tests/integration/focus-test.js
@@ -17,6 +17,17 @@ test('It accepts an HTMLElement as first argument', function(assert) {
   focus(document.querySelector('.target-element'));
 });
 
+test('It accepts a CSS selector as first argument', function(assert) {
+  assert.expect(2);
+  this.onFocus = (e) => {
+    assert.ok(true, 'a focus event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+  };
+
+  this.render(hbs`<input class="target-element" onfocus={{onFocus}} />`);
+  focus('.target-element');
+});
+
 test('It blurs the focused input before firing focus event on another one', function(assert) {
   let docIsFocused = document.hasFocus && document.hasFocus();
   let assertions = docIsFocused ? 8 : 4;


### PR DESCRIPTION
@pixelhandler You thought about this. I actually found a situation where it's needed, so I made it public (and enhance it to accept either a selector or a HTMLElement)