### PR TITLE
Fixes strict mode & running in node 4

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,4 +1,6 @@
 /* eslint-env node */
+'use strict';
+
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "loader.js": "^4.2.3"
   },
   "engines": {
-    "node": ">= 4"
+    "node": ">= 6"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "loader.js": "^4.2.3"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 4"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,4 +1,6 @@
 /* eslint-env node */
+'use strict';
+
 let browsers = [
   'ie 9',
   'last 1 Chrome versions',


### PR DESCRIPTION
Relates to https://github.com/cibernox/ember-native-dom-helpers/issues/52
~~Fancy features are used in this repo, so requires node 6+~~
EDIT: using strict mode if in node 4