### PR TITLE
Blur event

### DIFF
--- a/addon-test-support/blur.js
+++ b/addon-test-support/blur.js
@@ -1,0 +1,34 @@
+import Ember from 'ember';
+import getElementWithAssert from './-private/get-element-with-assert';
+import { fireEvent } from './fire-event';
+import wait from 'ember-test-helpers/wait';
+
+const { run } = Ember;
+
+/*
+  @method blur
+  @param {String|HTMLElement} selector
+  @return {RSVP.Promise}
+  @public
+*/
+export function blur(selector) {
+  if (!selector) { return; }
+  let el = getElementWithAssert(selector);
+
+  if (el.tagName === 'INPUT' || el.contentEditable || el.tagName === 'A') {
+    let { type } = el;
+    if (type !== 'checkbox' && type !== 'radio' && type !== 'hidden') {
+      run(null, function() {
+        // Chrome/Firefox does not trigger the `blur` event if the window
+        // does not have focus. If the document does not have focus then
+        // fire `blur` event via native event.
+        if (document.hasFocus && !document.hasFocus()) {
+          fireEvent(el, 'blur', null, false); // blur does not bubble
+        } else {
+          el.blur();
+        }
+      });
+    }
+  }
+  return (window.wait || wait)();
+}

--- a/tests/integration/blur-test.js
+++ b/tests/integration/blur-test.js
@@ -1,0 +1,66 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { blur } from 'ember-native-dom-helpers/blur';
+
+moduleForComponent('blur', 'Integration | Test Helper | blur', {
+  integration: true
+});
+
+test('It accepts an HTMLElement as first argument', function(assert) {
+  assert.expect(2);
+  this.onBlur = (e) => {
+    assert.ok(true, 'a blur event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+  };
+
+  this.render(hbs`<input class="target-element" onblur={{onBlur}} />`);
+
+  let targetElement = document.querySelector('.target-element');
+
+  targetElement.focus();
+  blur(targetElement);
+});
+
+test('It accepts a CSS selector as first argument', function(assert) {
+  assert.expect(2);
+  this.onBlur = (e) => {
+    assert.ok(true, 'a blur event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+  };
+
+  this.render(hbs`<input class="target-element" onblur={{onBlur}} />`);
+
+  document.querySelector('.target-element').focus();
+  blur('.target-element');
+});
+
+test('It resets focus to body, when blur event was fired', function(assert) {
+  let docIsFocused = document.hasFocus && document.hasFocus();
+  let assertions = docIsFocused ? 5 : 4;
+
+  assert.expect(assertions);
+
+  this.onBlur = (e) => {
+    assert.ok(true, 'a blur event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+  };
+
+  this.render(hbs`
+    <input class="target-element" onblur={{onBlur}} />
+    <input class="other-element" />
+  `);
+
+  let [bodyElement] = document.getElementsByTagName('body');
+  let targetElement = document.querySelector('.target-element');
+
+  assert.equal(document.activeElement, bodyElement, 'body is focused by default');
+
+  targetElement.focus();
+  assert.equal(document.activeElement, targetElement, '.target-element has focus');
+
+  blur('.target-element');
+
+  if (docIsFocused) {
+    assert.equal(document.activeElement, bodyElement, 'body regained focus after blur');
+  }
+});


### PR DESCRIPTION
Alongside the focus event, I've added blur event as well. Blur seems to have similar issues when the browser is not focused, tests will fail. Triggering native event helps, event though I am not exactly sure, that it will result in 'exactly' the same behavior.

What you guys think?