### PR TITLE
Improve focus/blur/keyboard events handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ test('Usage awaiting the world to settle', async function(assert) {
 - `find(selector, contextHTMLElement)` (query for an element in test DOM, `#ember-testing`)
 - `findAll(selector, contextHTMLElement)` (query for elements in test DOM, `#ember-testing`)
 - `findWithAssert(selector, contextHTMLElement)` (same as `find`, but raises an Error if no result)
-- `keyEvent(selectorOrHTMLElement, type, keyCode)` (type being `keydown`, `keyup` or `keypress`)
+- `keyEvent(selectorOrHTMLElement, type, keyCode, modifiers)` (type being `keydown`, `keyup` or `keypress`, modifiers being object with `{ ctrlKey: false, altKey: false, shiftKey: false, metaKey: false }`)
 - `triggerEvent(selectorOrHTMLElement, type, options)`
 - `focus(selectorOrHTMLElement)`
 - `blur(selectorOrHTMLElement)`

--- a/addon-test-support/-private/is-focusable.js
+++ b/addon-test-support/-private/is-focusable.js
@@ -6,5 +6,5 @@ export default function isFocusable(el) {
     return false;
   }
 
-  return focusableTags.includes(tagName) || el.contentEditable;
+  return focusableTags.indexOf(tagName) > -1 || el.contentEditable;
 }

--- a/addon-test-support/-private/is-focusable.js
+++ b/addon-test-support/-private/is-focusable.js
@@ -1,0 +1,10 @@
+export default function isFocusable(el) {
+  let focusableTags = ['INPUT', 'BUTTON', 'LINK', 'SELECT', 'A', 'TEXTAREA'];
+  let { tagName, type } = el;
+
+  if (type === 'hidden') {
+    return false;
+  }
+
+  return focusableTags.includes(tagName) || el.contentEditable;
+}

--- a/addon-test-support/blur.js
+++ b/addon-test-support/blur.js
@@ -29,7 +29,7 @@ export function blur(selector) {
       // does not have focus. If the document does not have focus then
       // fire `blur` event via native event.
       if (browserIsNotFocused) {
-        fireEvent(el, 'blur', { bubble: false });
+        fireEvent(el, 'blur', { bubbles: false });
       }
     });
   }

--- a/addon-test-support/blur.js
+++ b/addon-test-support/blur.js
@@ -23,7 +23,9 @@ export function blur(selector) {
         // does not have focus. If the document does not have focus then
         // fire `blur` event via native event.
         if (document.hasFocus && !document.hasFocus()) {
-          fireEvent(el, 'blur', null, false); // blur does not bubble
+          fireEvent(el, 'blur', {
+            bubble: false
+          });
         } else {
           el.blur();
         }

--- a/addon-test-support/blur.js
+++ b/addon-test-support/blur.js
@@ -19,12 +19,16 @@ export function blur(selector) {
 
   if (isFocusable(el)) {
     run(null, function() {
+      let browserIsNotFocused = document.hasFocus && !document.hasFocus();
+
+      // makes `document.activeElement` be `body`.
+      // If the browser is focused, it also fires a blur event
       el.blur();
 
       // Chrome/Firefox does not trigger the `blur` event if the window
       // does not have focus. If the document does not have focus then
       // fire `blur` event via native event.
-      if (document.hasFocus && !document.hasFocus()) {
+      if (browserIsNotFocused) {
         fireEvent(el, 'blur', { bubble: false });
       }
     });

--- a/addon-test-support/blur.js
+++ b/addon-test-support/blur.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import getElementWithAssert from './-private/get-element-with-assert';
+import isFocusable from './-private/is-focusable';
 import { fireEvent } from './fire-event';
 import wait from 'ember-test-helpers/wait';
 
@@ -13,24 +14,21 @@ const { run } = Ember;
 */
 export function blur(selector) {
   if (!selector) { return; }
+
   let el = getElementWithAssert(selector);
 
-  if (el.tagName === 'INPUT' || el.contentEditable || el.tagName === 'A') {
-    let { type } = el;
-    if (type !== 'checkbox' && type !== 'radio' && type !== 'hidden') {
-      run(null, function() {
-        // Chrome/Firefox does not trigger the `blur` event if the window
-        // does not have focus. If the document does not have focus then
-        // fire `blur` event via native event.
-        if (document.hasFocus && !document.hasFocus()) {
-          fireEvent(el, 'blur', {
-            bubble: false
-          });
-        } else {
-          el.blur();
-        }
-      });
-    }
+  if (isFocusable(el)) {
+    run(null, function() {
+      el.blur();
+
+      // Chrome/Firefox does not trigger the `blur` event if the window
+      // does not have focus. If the document does not have focus then
+      // fire `blur` event via native event.
+      if (document.hasFocus && !document.hasFocus()) {
+        fireEvent(el, 'blur', { bubble: false });
+      }
+    });
   }
+
   return (window.wait || wait)();
 }

--- a/addon-test-support/fire-event.js
+++ b/addon-test-support/fire-event.js
@@ -42,14 +42,12 @@ export function fireEvent(element, type, options = {}) {
   @method buildBasicEvent
   @param {String} type
   @param {Object} (optional) options
-  @param {Boolean} (optional) bubbles
-  @param {Boolean} (optional) cancelable
   @return {Event}
   @private
 */
-function buildBasicEvent(type, options = {}, bubbles = true, cancelable = true) {
+function buildBasicEvent(type, options = {}) {
   let event = document.createEvent('Events');
-  event.initEvent(type, bubbles, cancelable);
+  event.initEvent(type, true, true);
   merge(event, options);
   return event;
 }

--- a/addon-test-support/fire-event.js
+++ b/addon-test-support/fire-event.js
@@ -47,7 +47,16 @@ export function fireEvent(element, type, options = {}) {
 */
 function buildBasicEvent(type, options = {}) {
   let event = document.createEvent('Events');
-  event.initEvent(type, true, true);
+
+  let bubbles = options.bubbles !== undefined ? options.bubbles : true;
+  let cancelable = options.cancelable !== undefined ? options.cancelable : true;
+
+  delete options.bubbles;
+  delete options.cancelable;
+
+  // bubbles and cancelable are readonly, so they can be
+  // set when initializing event
+  event.initEvent(type, bubbles, cancelable);
   merge(event, options);
   return event;
 }
@@ -105,6 +114,9 @@ function buildKeyboardEvent(type, options = {}) {
     // keyCode/which will be 0. Also, keyCode and which now are string
     // and if app compare it with === with integer key definitions,
     // there will be a fail.
+    //
+    // https://w3c.github.io/uievents/#interface-keyboardevent
+    // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
     Object.defineProperty(event, 'keyCode', {
       get() {
         return parseInt(this.key);

--- a/addon-test-support/fire-event.js
+++ b/addon-test-support/fire-event.js
@@ -94,11 +94,54 @@ function buildMouseEvent(type, options = {}) {
   @private
 */
 function buildKeyboardEvent(type, options = {}) {
-  let event;
+  return buildBasicEvent(type, options);
+}
+
+/**
+ * TODO: figure out what is a better solution for keyboard event.
+ * It seems that if we use KeyboardEvent, its not bubbling correctly.
+ *
+ * @method buildKeyboardEvent
+ * @param {String} type
+ * @param {Object} [options]
+ * @return {Event}
+ * @private
+ */
+function _buildKeyboardEvent(type, options = {}) {
+  let eventOpts = merge(merge({}, DEFAULT_EVENT_OPTIONS), options);
+  let event, eventMethodName;
+
   try {
-    event = document.createEvent('KeyEvents');
-    let eventOpts = merge(merge({}, DEFAULT_EVENT_OPTIONS), options);
-    event.initKeyEvent(
+    event = new KeyboardEvent(type, eventOpts);
+    Object.defineProperty(event, 'charCode', {
+      get() {
+        return this.key;
+      }
+    });
+
+    return event;
+  } catch(e) {
+    // left intentionally blank
+  }
+
+  try {
+    event = document.createEvent('KeyboardEvents');
+    eventMethodName = 'initKeyboardEvent';
+  } catch(e) {
+    // left intentionally blank
+  }
+
+  if (!event) {
+    try {
+      event = document.createEvent('KeyEvents');
+      eventMethodName = 'initKeyEvent';
+    } catch(e) {
+      // left intentionally blank
+    }
+  }
+
+  if (event) {
+    event[eventMethodName](
       type,
       eventOpts.canBubble,
       eventOpts.cancelable,
@@ -110,8 +153,9 @@ function buildKeyboardEvent(type, options = {}) {
       eventOpts.keyCode,
       eventOpts.charCode
     );
-  } catch (e) {
+  } else {
     event = buildBasicEvent(type, options);
   }
+
   return event;
 }

--- a/addon-test-support/focus.js
+++ b/addon-test-support/focus.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import getElementWithAssert from './-private/get-element-with-assert';
+import isFocusable from './-private/is-focusable';
 import { fireEvent } from './fire-event';
 import wait from 'ember-test-helpers/wait';
 
@@ -13,32 +14,31 @@ const { run } = Ember;
 */
 export function focus(selector) {
   if (!selector) { return; }
+
   let el = getElementWithAssert(selector);
 
-  if (el.tagName === 'INPUT' || el.contentEditable || el.tagName === 'A') {
-    let type = el.type;
-    if (type !== 'checkbox' && type !== 'radio' && type !== 'hidden') {
-      run(null, function() {
-        let browserIsNotFocused = document.hasFocus && !document.hasFocus();
+  if (isFocusable(el)) {
+    run(null, function() {
+      let browserIsNotFocused = document.hasFocus && !document.hasFocus();
 
-        // Firefox does not trigger the `focusin` event if the window
-        // does not have focus. If the document does not have focus then
-        // fire `focusin` event as well.
-        if (browserIsNotFocused) {
-          fireEvent(el, 'focusin');
-        }
+      // Firefox does not trigger the `focusin` event if the window
+      // does not have focus. If the document does not have focus then
+      // fire `focusin` event as well.
+      if (browserIsNotFocused) {
+        fireEvent(el, 'focusin');
+      }
 
-        // makes `document.activeElement` be `el`. If the browser is focused, it also fires a focus event
-        el.focus();
+      // makes `document.activeElement` be `el`. If the browser is focused, it also fires a focus event
+      el.focus();
 
-        // if the browser is not focused the previous `el.focus()` didn't fire an event, so we simulate it
-        if (browserIsNotFocused) {
-          fireEvent(el, 'focus', {
-            bubble: false
-          });
-        }
-      });
-    }
+      // if the browser is not focused the previous `el.focus()` didn't fire an event, so we simulate it
+      if (browserIsNotFocused) {
+        fireEvent(el, 'focus', {
+          bubble: false
+        });
+      }
+    });
   }
+
   return (window.wait || wait)();
 }

--- a/addon-test-support/focus.js
+++ b/addon-test-support/focus.js
@@ -19,19 +19,23 @@ export function focus(selector) {
     let type = el.type;
     if (type !== 'checkbox' && type !== 'radio' && type !== 'hidden') {
       run(null, function() {
+        let browserIsNotFocused = document.hasFocus && !document.hasFocus();
+
         // Firefox does not trigger the `focusin` event if the window
         // does not have focus. If the document does not have focus then
         // fire `focusin` event as well.
-        let browserIsNotFocused = document.hasFocus && !document.hasFocus();
-
         if (browserIsNotFocused) {
           fireEvent(el, 'focusin');
         }
 
-        el.focus(); // makes `document.activeElement` be `el`. If the browser is focused, it also fires a focus event
+        // makes `document.activeElement` be `el`. If the browser is focused, it also fires a focus event
+        el.focus();
 
+        // if the browser is not focused the previous `el.focus()` didn't fire an event, so we simulate it
         if (browserIsNotFocused) {
-          fireEvent(el, 'focus', null, false); // if the browser is not focused the previous `el.focus()` didn't fire an event, so we simulate it
+          fireEvent(el, 'focus', {
+            bubble: false
+          });
         }
       });
     }

--- a/addon-test-support/focus.js
+++ b/addon-test-support/focus.js
@@ -25,7 +25,9 @@ export function focus(selector) {
       // does not have focus. If the document does not have focus then
       // fire `focusin` event as well.
       if (browserIsNotFocused) {
-        fireEvent(el, 'focusin');
+        fireEvent(el, 'focusin', {
+          bubbles: false
+        });
       }
 
       // makes `document.activeElement` be `el`. If the browser is focused, it also fires a focus event
@@ -34,7 +36,7 @@ export function focus(selector) {
       // if the browser is not focused the previous `el.focus()` didn't fire an event, so we simulate it
       if (browserIsNotFocused) {
         fireEvent(el, 'focus', {
-          bubble: false
+          bubbles: false
         });
       }
     });

--- a/addon-test-support/focus.js
+++ b/addon-test-support/focus.js
@@ -22,11 +22,16 @@ export function focus(selector) {
         // Firefox does not trigger the `focusin` event if the window
         // does not have focus. If the document does not have focus then
         // fire `focusin` event as well.
-        if (document.hasFocus && !document.hasFocus()) {
+        let browserIsNotFocused = document.hasFocus && !document.hasFocus();
+
+        if (browserIsNotFocused) {
           fireEvent(el, 'focusin');
-          fireEvent(el, 'focus', null, false); // focus does not bubble
-        } else {
-          el.focus();
+        }
+
+        el.focus(); // makes `document.activeElement` be `el`. If the browser is focused, it also fires a focus event
+
+        if (browserIsNotFocused) {
+          fireEvent(el, 'focus', null, false); // if the browser is not focused the previous `el.focus()` didn't fire an event, so we simulate it
         }
       });
     }

--- a/addon-test-support/key-event.js
+++ b/addon-test-support/key-event.js
@@ -1,11 +1,16 @@
 import { triggerEvent } from './trigger-event';
+import Ember from 'ember';
 
-/*
-  @method keyEvent
-  @param {String|HTMLElement} selector
-  @param {String} type
-  @param {Number} keyCode
-*/
-export function keyEvent(selector, type, keyCode) {
-  return triggerEvent(selector, type, { keyCode, which: keyCode });
+const { merge } = Ember;
+
+/**
+ * @public
+ * @param selector
+ * @param type
+ * @param keyCode
+ * @param modifiers
+ * @return {*}
+ */
+export function keyEvent(selector, type, keyCode, modifiers = { ctrlKey: false, altKey: false, shiftKey: false, metaKey: false }) {
+  return triggerEvent(selector, type, merge({ keyCode, which: keyCode, key: keyCode }, modifiers));
 }


### PR DESCRIPTION
When the window is focused and unfocused, event triggering works differently. 

1. When the window is unfocused, `el.focus()` is only setting document.activeElement = el;
2. When the window is focused, `el.focus` will set document.activeElement and will also trigger focus event.

This PR will simulate this behavior and help to be consistent between focused and unfocused window.