### PR TITLE
Allow to pass a context HTMLElement to `click`

### DIFF
--- a/addon-test-support/click.js
+++ b/addon-test-support/click.js
@@ -20,11 +20,19 @@ export function clickEventSequence(el, options) {
 /*
   @method click
   @param {String|HTMLElement} selector
+  @param {HTMLElement} context
   @param {Object} options
   @return {RSVP.Promise}
   @public
 */
-export function click(selector, options = {}) {
-  clickEventSequence(getElementWithAssert(selector), options);
+export function click(selector, context, options) {
+  let element;
+  if (context instanceof HTMLElement) {
+    element = getElementWithAssert(selector, context);
+  } else {
+    options = context || {};
+    element = getElementWithAssert(selector);
+  }
+  clickEventSequence(element, options);
   return (window.wait || wait)();
 }

--- a/tests/integration/click-test.js
+++ b/tests/integration/click-test.js
@@ -51,6 +51,21 @@ test('It accepts an HTMLElement as first argument', function(assert) {
   click(document.querySelector('.target-element'));
 });
 
+test('It accepts an HTMLElement as second argument to scope the search to a parent', function(assert) {
+  assert.expect(3);
+  this.onClick = (e) => {
+    assert.ok(true, 'a click event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+    assert.ok(e.target.classList.contains('cell-2'), 'The cell of the second row was clicked');
+  };
+
+  this.render(hbs`
+    <div class="row-1"><div class="cell cell-1" onclick={{action onClick}}></div></div>
+    <div class="row-2"><div class="cell cell-2" onclick={{action onClick}}></div></div>
+  `);
+  click('.cell', document.querySelector('.row-2'));
+});
+
 test('works in the SVG namespace', function(assert) {
   assert.expect(1);
   this.onClick = () => {
@@ -71,3 +86,84 @@ test('works when it receives an SVG Element', function(assert) {
   click(document.querySelector('#the-path'));
 });
 
+test('in can receive an object of options as second argument, that is reused for all the mouse events fired in sequence', function(assert) {
+  assert.expect(18);
+  let index = 0;
+  this.onMouseDown = (e) => {
+    assert.equal(++index, 1, 'mousedown is fired first');
+    assert.ok(true, 'a mousedown event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+    assert.equal(e.screenX, 999, 'The screenX value was taken from the passed options');
+    assert.equal(e.screenY, 888, 'The screenX value was taken from the passed options');
+  };
+  this.onFocus = (e) => {
+    assert.equal(++index, 2, 'focus is fired second');
+    assert.ok(true, 'a focus event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+  };
+  this.onMouseUp = (e) => {
+    assert.equal(++index, 3, 'mouseup is fired third');
+    assert.ok(true, 'a mouseup event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+    assert.equal(e.screenX, 999, 'The screenX value was taken from the passed options');
+    assert.equal(e.screenY, 888, 'The screenX value was taken from the passed options');
+  };
+  this.onClick = (e) => {
+    assert.equal(++index, 4, 'click is fired third');
+    assert.ok(true, 'a click event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+    assert.equal(e.screenX, 999, 'The screenX value was taken from the passed options');
+    assert.equal(e.screenY, 888, 'The screenX value was taken from the passed options');
+  };
+
+  this.render(hbs`
+    <input class="target-element"
+      onmouseup={{onMouseUp}}
+      onfocus={{onFocus}}
+      onclick={{onClick}}
+      onmousedown={{onMouseDown}} />
+  `);
+  click('.target-element', { screenX: 999, screenY: 888 });
+});
+
+test('in can receive an object of options as third argument if the second argument is a context HTMLElement', function(assert) {
+  assert.expect(18);
+  let index = 0;
+  this.onMouseDown = (e) => {
+    assert.equal(++index, 1, 'mousedown is fired first');
+    assert.ok(true, 'a mousedown event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+    assert.equal(e.screenX, 999, 'The screenX value was taken from the passed options');
+    assert.equal(e.screenY, 888, 'The screenX value was taken from the passed options');
+  };
+  this.onFocus = (e) => {
+    assert.equal(++index, 2, 'focus is fired second');
+    assert.ok(true, 'a focus event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+  };
+  this.onMouseUp = (e) => {
+    assert.equal(++index, 3, 'mouseup is fired third');
+    assert.ok(true, 'a mouseup event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+    assert.equal(e.screenX, 999, 'The screenX value was taken from the passed options');
+    assert.equal(e.screenY, 888, 'The screenX value was taken from the passed options');
+  };
+  this.onClick = (e) => {
+    assert.equal(++index, 4, 'click is fired third');
+    assert.ok(true, 'a click event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+    assert.equal(e.screenX, 999, 'The screenX value was taken from the passed options');
+    assert.equal(e.screenY, 888, 'The screenX value was taken from the passed options');
+  };
+
+  this.render(hbs`
+    <div class="wrapper-target-test">
+      <input class="target-element"
+        onmouseup={{onMouseUp}}
+        onfocus={{onFocus}}
+        onclick={{onClick}}
+        onmousedown={{onMouseDown}} />
+    </div>
+  `);
+  click('.target-element', document.querySelector('.wrapper-target-test'), { screenX: 999, screenY: 888 });
+});


### PR DESCRIPTION
This is so to behave like the helper provided by ember