### PR TITLE
findAll(): Return JS array instead of NodeList

### DIFF
--- a/addon-test-support/find-all.js
+++ b/addon-test-support/find-all.js
@@ -20,5 +20,13 @@ export function findAll(selector, contextEl) {
   } else {
     result = document.querySelectorAll(`${settings.rootElement} ${selector}`);
   }
-  return result;
+  return toArray(result);
+}
+
+function toArray(nodelist) {
+  let array = new Array(nodelist.length);
+  for (let i = 0; i < nodelist.length; i++) {
+    array[i] = nodelist[i];
+  }
+  return array;
 }

--- a/tests/integration/find-all-test.js
+++ b/tests/integration/find-all-test.js
@@ -13,7 +13,7 @@ test('with empty query result, findAll resturns empty NodeList', function(assert
   `);
   let expected = document.querySelectorAll('.hidden');
   let actual = findAll('.hidden');
-  assert.ok(actual instanceof NodeList, 'NodeList instance found');
+  assert.ok(Array.isArray(actual), 'Array found');
   assert.strictEqual(actual.length, expected.length, 'empty NodeList returned for an empty query');
 });
 
@@ -45,7 +45,7 @@ test('findAll returns the resulting node list', function(assert) {
 
   let expected = document.querySelectorAll('#ember-testing li:last-child');
   let actual = findAll('li:last-child');
-  assert.ok(actual instanceof NodeList, 'NodeList instance found');
+  assert.ok(Array.isArray(actual), 'Array found');
   assert.strictEqual(actual[0], expected[0], 'one li:last-child element found within #ember-testing');
   assert.strictEqual(actual[1], expected[1], 'two li:last-child elements found within #ember-testing');
 });


### PR DESCRIPTION
Resolves #77 

/cc @cibernox @rwjblue 