### PR TITLE
Added a 'triggerFileSelect' method to test selecting of files

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -14,4 +14,5 @@ export { focus } from './focus';
 export { blur } from './blur';
 export { scrollTo } from './scroll-to';
 export { currentRouteName } from './current-route-name';
+export { selectFiles } from './select-files';
 export { default as settings } from './settings';

--- a/addon-test-support/select-files.js
+++ b/addon-test-support/select-files.js
@@ -1,0 +1,32 @@
+import Ember from 'ember';
+import getElementWithAssert from './-private/get-element-with-assert';
+import { fireEvent } from './fire-event';
+import wait from 'ember-test-helpers/wait';
+
+const { run, assert, isArray } = Ember;
+
+/*
+  @method selectFiles
+  @param {String|HTMLElement} selector
+  @param {Array} flies
+  @return {RSVP.Promise}
+  @public
+*/
+export function selectFiles(selector, files = []) {
+  let element = getElementWithAssert(selector);
+
+  assert(`This is only used with file inputs.
+          Either change to a 'type="file"' or use the 'triggerEvent' helper.`,
+          element.type === 'file');
+
+  if (!isArray(files)) {
+    files = [files];
+  }
+
+  assert(`Can only handle multiple slection when an input is set to allow for multiple files.
+          Please add the property "multiple" to your file input.`,
+          element.multiple || files.length <= 1);
+
+  run(() => fireEvent(element, 'change', files));
+  return (window.wait || wait)();
+}

--- a/tests/integration/select-files-test.js
+++ b/tests/integration/select-files-test.js
@@ -1,0 +1,70 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import { selectFiles } from 'ember-native-dom-helpers';
+
+moduleForComponent('selectFiles', 'Integration | Test Helper | selectFiles', {
+  integration: true
+});
+
+test('It provids a file under the events target', function(assert) {
+  assert.expect(3);
+  this.onChange = (e) => {
+    assert.equal(e.target.files.length, 1, 'file is present');
+    assert.equal(e.target.files[0].type, 'plain/text', 'file has the set type');
+    assert.equal(e.target.files[0].size, 7, 'file has the set size');
+  };
+
+  this.render(hbs`<input class="target-element" type="file" onchange={{onChange}} />`);
+  selectFiles('.target-element', new Blob(['texters'], { type: 'plain/text' }));
+});
+
+test('Ability to handle multiple files', function(assert) {
+  assert.expect(5);
+  this.onChange = (e) => {
+    assert.equal(e.target.files.length, 2, 'files are present');
+    assert.equal(e.target.files[0].type, 'plain/text', 'first file has the set type');
+    assert.equal(e.target.files[0].size, 7, 'first file has the set size');
+    assert.equal(e.target.files[1].type, 'image/jpeg', 'second file has the set type');
+    assert.equal(e.target.files[1].size, 14, 'second file has the set size');
+  };
+
+  this.render(hbs`<input class="target-element" type="file" multiple onchange={{onChange}} />`);
+  selectFiles('.target-element', [
+    new Blob(['texters'], { type: 'plain/text' }),
+    new Blob(['images_texters'], { type: 'image/jpeg' })
+  ]);
+});
+
+test('Throws assertion if multiple files passed to a single file input', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`<input class="target-element" type="file" onchange={{onChange}} />`);
+
+  assert.throws(function() {
+    selectFiles('.target-element', [
+      new Blob(['texters'], { type: 'plain/text' }),
+      new Blob(['images_texters'], { type: 'image/jpeg' })
+    ]);
+  }, 'throws assertion if multiple files are passes to a non file input');
+});
+
+test('It does not add a file to a non file input', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`<input class="target-element" type="number" onchange={{onChange}} />`);
+
+  assert.throws(function() {
+    selectFiles('.target-element', [new Blob(['texters'], { type: 'plain/text' })]);
+  }, 'throws assertion if used on a non file input element');
+});
+
+test('It accepts an HTMLElement as first argument', function(assert) {
+  assert.expect(2);
+  this.onChange = (e) => {
+    assert.ok(true, 'a click event is fired');
+    assert.ok(e instanceof window.Event, 'It receives a native event');
+  };
+
+  this.render(hbs`<input class="target-element" type="file" onchange={{onChange}} />`);
+  selectFiles(document.querySelector('.target-element'), new Blob(['texters'], { type: 'plain/text' }));
+});


### PR DESCRIPTION
In order to select files, you need to assign the file to the files property on the event's target. This is a readonly property, so need to use defineProperty in order to overwrite it.

Could do this to currentTarget as well if it's felt that would be beneficial. originalTarget and even explicitOriginalTarget should be left alone I feel for the sake of the test helper.

Closes #82