### PR TITLE
Allow the `context` received by findAll to be a CSS selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The codemod can't make a *perfect* convertion, but it will do most of the work f
 - `tap(selectorOrHTMLElement, eventOptions)`
 - `fillIn(selectorOrHTMLElement, text)`
 - `find(selector, contextHTMLElement)` (query for an element in test DOM, `#ember-testing`)
-- `findAll(selector, contextHTMLElement)` (query for elements in test DOM, `#ember-testing`)
+- `findAll(selector, context)` (query for elements in test DOM, `#ember-testing`)
 - `findWithAssert(selector, contextHTMLElement)` (same as `find`, but raises an Error if no result)
 - `keyEvent(selectorOrHTMLElement, type, keyCode, modifiers)` (type being `keydown`, `keyup` or `keypress`, modifiers being object with `{ ctrlKey: false, altKey: false, shiftKey: false, metaKey: false }`)
 - `triggerEvent(selectorOrHTMLElement, type, options)`

--- a/addon-test-support/find-all.js
+++ b/addon-test-support/find-all.js
@@ -9,14 +9,16 @@ import settings from './settings';
 
   @method findAll
   @param {String} CSS selector to find elements in the test DOM
-  @param {HTMLElement} contextEl to query within, query from its contained DOM
+  @param {HTMLElement|string} context to query within, query from its contained DOM
   @return {Array} An array of zero or more HTMLElement objects
   @public
 */
-export function findAll(selector, contextEl) {
+export function findAll(selector, context) {
   let result;
-  if (contextEl instanceof HTMLElement) {
-    result = contextEl.querySelectorAll(selector);
+  if (context instanceof HTMLElement) {
+    result = context.querySelectorAll(selector);
+  } else if (typeof context === 'string') {
+    result = document.querySelectorAll(`${settings.rootElement} ${context} ${selector}`);
   } else {
     result = document.querySelectorAll(`${settings.rootElement} ${selector}`);
   }

--- a/tests/integration/find-all-test.js
+++ b/tests/integration/find-all-test.js
@@ -52,14 +52,38 @@ test('findAll returns the resulting node list', function(assert) {
 
 test('findAll helper can use (optional) element as the context to query', function(assert) {
   this.render(hbs`
-    <select>
-      <option value="">Choose one</option>
-      <option value="0">Zero</option>
-      <option value="1" selected="selected">One</option>
-    </select>
+    <div>
+      <span>One</span>
+      <span>Two</span>
+      <span>Three</span>
+    </div>
+    <div class="second-set">
+      <span>One</span>
+      <span>Two</span>
+      <span>Three</span>
+    </div>
   `);
 
-  let expected = document.querySelectorAll('#ember-testing select option');
-  let actual = findAll('option', document.querySelector('select'));
-  assert.equal(actual.length, expected.length, 'select options found within #ember-testing');
+  let expected = document.querySelectorAll('#ember-testing .second-set span');
+  let actual = findAll('span', document.querySelector('.second-set'));
+  assert.equal(actual.length, expected.length);
+});
+
+test('findAll helper can use (optional) selector as the context to query', function(assert) {
+  this.render(hbs`
+    <div>
+      <span>One</span>
+      <span>Two</span>
+      <span>Three</span>
+    </div>
+    <div class="second-set">
+      <span>One</span>
+      <span>Two</span>
+      <span>Three</span>
+    </div>
+  `);
+
+  let expected = document.querySelectorAll('#ember-testing .second-set span');
+  let actual = findAll('span', '.second-set');
+  assert.equal(actual.length, expected.length);
 });


### PR DESCRIPTION
Before it could only be an HTMLElement