### PR TITLE
Fix waitUntil to call callback just once if it immediately returns truthy value

### DIFF
--- a/addon-test-support/wait-until.js
+++ b/addon-test-support/wait-until.js
@@ -6,6 +6,7 @@ export function waitUntil(callback, { timeout = 1000 } = {}) {
     let value = run(callback);
     if (value) {
       resolve(value);
+      return;
     }
     let time = 0;
     let tick = function() {


### PR DESCRIPTION
Before it would call the callback at least twice, first on the initial `waitUntil` call, and at least another time within the `tick` function, even if it returned a truthy value immediately and the returned Promise was already resolved.

For something like this...
```
await waitUntil(() => find('.foo').classList.contains('.bar'));
```

this could lead to an exception, when the second (superfluous) call was made after the test has finished already, so `find('.foo')` returns `null`.