### PR TITLE
feat: target support for mouse events

### DIFF
--- a/addon-test-support/fire-event.js
+++ b/addon-test-support/fire-event.js
@@ -99,6 +99,10 @@ function buildMouseEvent(type, options = {}) {
       eventOpts.metaKey,
       eventOpts.button,
       eventOpts.relatedTarget);
+
+    if (eventOpts.target !== undefined) {
+      Object.defineProperty(event, 'target', { value: eventOpts.target });
+    }
   } catch(e) {
     event = buildBasicEvent(type, options);
   }

--- a/tests/integration/click-test.js
+++ b/tests/integration/click-test.js
@@ -25,7 +25,7 @@ test('It fires mousedown, focus, mouseup and click events on the element with th
     assert.ok(e instanceof window.Event, 'It receives a native event');
   };
   this.onClick = (e) => {
-    assert.equal(++index, 4, 'click is fired third');
+    assert.equal(++index, 4, 'click is fired fourth');
     assert.ok(true, 'a click event is fired');
     assert.ok(e instanceof window.Event, 'It receives a native event');
   };


### PR DESCRIPTION
The mousemove event typically has a `target` property. For some reason, `initMouseEvent` doesn't allow one to pass this option in, so I used `Object.defineProperty`.