### PR TITLE
Allow the `context` received by find to be a CSS selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The codemod can't make a *perfect* convertion, but it will do most of the work f
 - `click(selectorOrHTMLElement, eventOptions)`
 - `tap(selectorOrHTMLElement, eventOptions)`
 - `fillIn(selectorOrHTMLElement, text)`
-- `find(selector, contextHTMLElement)` (query for an element in test DOM, `#ember-testing`)
+- `find(selector, context)` (query for an element in test DOM, `#ember-testing`)
 - `findAll(selector, context)` (query for elements in test DOM, `#ember-testing`)
 - `findWithAssert(selector, contextHTMLElement)` (same as `find`, but raises an Error if no result)
 - `keyEvent(selectorOrHTMLElement, type, keyCode, modifiers)` (type being `keydown`, `keyup` or `keypress`, modifiers being object with `{ ctrlKey: false, altKey: false, shiftKey: false, metaKey: false }`)

--- a/addon-test-support/-private/get-element.js
+++ b/addon-test-support/-private/get-element.js
@@ -7,16 +7,18 @@ import settings from '../settings';
   @return HTMLElement
   @private
 */
-export default function getElement(selectorOrElement, contextEl) {
-  if (selectorOrElement instanceof Window || 
-      selectorOrElement instanceof Document || 
-      selectorOrElement instanceof HTMLElement || 
-      selectorOrElement instanceof SVGElement) {
+export default function getElement(selectorOrElement, context) {
+  if (selectorOrElement instanceof Window ||
+    selectorOrElement instanceof Document ||
+    selectorOrElement instanceof HTMLElement ||
+    selectorOrElement instanceof SVGElement) {
     return selectorOrElement;
   }
   let result;
-  if (contextEl instanceof HTMLElement) {
-    result = contextEl.querySelector(selectorOrElement);
+  if (context instanceof HTMLElement) {
+    result = context.querySelector(selectorOrElement);
+  } else if (typeof context === 'string') {
+    result = document.querySelector(`${settings.rootElement} ${context} ${selectorOrElement}`);
   } else {
     result = document.querySelector(`${settings.rootElement} ${selectorOrElement}`);
   }

--- a/tests/integration/find-test.js
+++ b/tests/integration/find-test.js
@@ -60,6 +60,29 @@ test('find helper can use (optional) element as the context to query', function(
   assert.strictEqual(actual, expected, 'option found within select element');
 });
 
+test('find helper can use (optional) selector as the context to query', function(assert) {
+  this.render(hbs`
+    <select class="first-select">
+      <option value="">Choose one</option>
+      <option value="0">Zero</option>
+      <option value="1" selected="selected">One</option>
+    </select>
+    <select class="second-select">
+      <option value="">Choose one</option>
+      <option value="2">Two</option>
+      <option value="1" selected="selected">Three</option>
+    </select>
+  `);
+
+  let expected = document.querySelector('#ember-testing select');
+  let actual = find('select');
+  assert.strictEqual(actual, expected, 'select found within #ember-testing');
+
+  expected = document.querySelector('#ember-testing .second-select option[selected]');
+  actual = find('option[selected]', '.second-select');
+  assert.strictEqual(actual, expected, 'option found within select element');
+});
+
 test('find can use window and document', function(assert) {
   this.render(hbs`<div>Empty</div>`);
 


### PR DESCRIPTION
Before it could only be an HTMLElement