### PR TITLE
There is no point in receiving a string as context.

### DIFF
--- a/addon-test-support/find-all.js
+++ b/addon-test-support/find-all.js
@@ -9,7 +9,7 @@ import settings from './settings';
 
   @method findAll
   @param {String} CSS selector to find elements in the test DOM
-  @param {HTMLElement|string} context to query within, query from its contained DOM
+  @param {HTMLElement} context to query within, query from its contained DOM
   @return {Array} An array of zero or more HTMLElement objects
   @public
 */
@@ -17,8 +17,6 @@ export function findAll(selector, context) {
   let result;
   if (context instanceof HTMLElement) {
     result = context.querySelectorAll(selector);
-  } else if (typeof context === 'string') {
-    result = document.querySelectorAll(`${settings.rootElement} ${context} ${selector}`);
   } else {
     result = document.querySelectorAll(`${settings.rootElement} ${selector}`);
   }

--- a/tests/integration/find-all-test.js
+++ b/tests/integration/find-all-test.js
@@ -6,7 +6,7 @@ moduleForComponent('findAll', 'Integration | Test Helper | findAll', {
   integration: true
 });
 
-test('with empty query result, findAll resturns empty NodeList', function(assert) {
+test('with empty query result, findAll returns empty NodeList', function(assert) {
   this.render(hbs`
     <p class='hiding'>You can't find me</p>
     <p class='hiding'>I'm hidden as well</p>
@@ -84,6 +84,6 @@ test('findAll helper can use (optional) selector as the context to query', funct
   `);
 
   let expected = document.querySelectorAll('#ember-testing .second-set span');
-  let actual = findAll('span', '.second-set');
+  let actual = findAll('span', document.querySelector('.second-set'));
   assert.equal(actual.length, expected.length);
 });


### PR DESCRIPTION
Instead of passing two strings, the user can just as well join them