### PR TITLE
[wip] polyfill `keyCode` and `which` for BasicEvent

### DIFF
--- a/addon-test-support/fire-event.js
+++ b/addon-test-support/fire-event.js
@@ -174,6 +174,8 @@ function buildKeyboardEvent(type, options = {}) {
       eventOpts.charCode
     );
   } else {
+    options.which = options.keyCode = parseInt(options.key);
+
     event = buildBasicEvent(type, options);
   }
 


### PR DESCRIPTION
see #112 

This fixes issue in IE locally.

I'm not sure what would be the right approach with this code path https://github.com/ro0gr/ember-native-dom-helpers/blob/03feba2b2d818c2a186679783e3e8b3be9cd9490/addon-test-support/fire-event.js#L164-L175, seems like it's still have the same issue. 

There is no test in place yet. 
I think the best would be to have tests at least for IE11. At this moment tests fail in IE due to syntax errors.

Of course we could try to emulate desired behavior in Chrome, but I would like to ask first if there any plans to add IE to the test matrix?