### PR TITLE
Fixes rootElement to match that of this.$()[0]

### DIFF
--- a/addon-test-support/settings.js
+++ b/addon-test-support/settings.js
@@ -5,7 +5,7 @@
 */
 class TestSupportSettings {
 
-  constructor(init = { rootElement: '#ember-testing' }) {
+  constructor(init = { rootElement: '#ember-testing > .ember-view' }) {
     this._rootElement = init.rootElement;
   }
 

--- a/tests/integration/find-test.js
+++ b/tests/integration/find-test.js
@@ -72,3 +72,11 @@ test('find without args returns root element', function(assert) {
 
   assert.strictEqual(find(), document.querySelector(settings.rootElement), 'find() returns rootElement');
 });
+
+test('find works with the right rootElement', function(assert) {
+  this.render(hbs`<div id="first-child"></div>`);
+
+  let firstChild = document.querySelector('#first-child');
+
+  assert.strictEqual(find(':first-child'), firstChild, ':first-child returns the first element');
+});

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -3,10 +3,6 @@ import {
   setResolver
 } from 'ember-qunit';
 import { start } from 'ember-cli-qunit';
-import { settings } from 'ember-native-dom-helpers';
-import config from '../config/environment';
 
 setResolver(resolver);
-const { APP: { rootElement } } = config;
-settings.rootElement = rootElement || settings.rootElement;
 start();


### PR DESCRIPTION
Fixes #63

See https://github.com/emberjs/ember-test-helpers/blob/1e505a9de65b6a6352abc16698df7e3eb816c151/addon-test-support/%40ember/test-helpers/setup-rendering-context.js#L152

Hopefully this will not affect too many users, but might still be a breaking change for some, so probably would require a minor version bump?