### PR TITLE
findAll can accept SVG as second argument

### DIFF
--- a/addon-test-support/find-all.js
+++ b/addon-test-support/find-all.js
@@ -9,13 +9,13 @@ import settings from './settings';
 
   @method findAll
   @param {String} CSS selector to find elements in the test DOM
-  @param {HTMLElement} context to query within, query from its contained DOM
+  @param {Element} context to query within, query from its contained DOM
   @return {Array} An array of zero or more HTMLElement objects
   @public
 */
 export function findAll(selector, context) {
   let result;
-  if (context instanceof HTMLElement) {
+  if (context instanceof Element) {
     result = context.querySelectorAll(selector);
   } else {
     result = document.querySelectorAll(`${settings.rootElement} ${selector}`);

--- a/tests/integration/find-all-test.js
+++ b/tests/integration/find-all-test.js
@@ -87,3 +87,22 @@ test('findAll helper can use (optional) selector as the context to query', funct
   let actual = findAll('span', document.querySelector('.second-set'));
   assert.equal(actual.length, expected.length);
 });
+
+test('findAll helper can use (optional) svg element as the context to query', function(assert) {
+  this.render(hbs`
+    <svg>
+      <g>One</g>
+      <g>Two</g>
+      <g>Three</g>
+    </svg>
+    <svg class="second-set">
+      <g>One</g>
+      <g>Two</g>
+      <g>Three</g>
+    </svg>
+  `);
+
+  let expected = document.querySelectorAll('#ember-testing .second-set g');
+  let actual = findAll('g', document.querySelector('.second-set'));
+  assert.equal(actual.length, expected.length);
+});


### PR DESCRIPTION
If an svg was passed to as the second argument to findAll it was ignored because it's not an instance of HTMLElement.