### PR TITLE
[BUGFIX] Allow to focus non-focusable-by-default elements if they have tabindex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.5.7
+- [BUGFIX] Non-focusable-by-default elements (p.e. `<div>`) are now focusable if they have tabindex.
+
+# 0.5.6
+- [FEATURE] `find()` invoked with no argument now returns the root element.
+
 # 0.5.5
 - [FEATURE] New `waitFor(selector, options)` helper, convenience for the most common cases of `waitUntil`.
 

--- a/addon-test-support/-private/is-focusable.js
+++ b/addon-test-support/-private/is-focusable.js
@@ -6,5 +6,5 @@ export default function isFocusable(el) {
     return false;
   }
 
-  return focusableTags.indexOf(tagName) > -1 || el.contentEditable === 'true';
+  return focusableTags.indexOf(tagName) > -1 || el.contentEditable === 'true' || el.tabIndex !== undefined;
 }

--- a/tests/integration/focus-test.js
+++ b/tests/integration/focus-test.js
@@ -35,7 +35,21 @@ test('it sets focus for contenteditable HTMLElement', function(assert) {
   assert.ok(document.querySelector('.target-element:focus'));
 });
 
-test('it does not set focus for non-contenteditable HTMLElement', function(assert) {
+test('it sets focus on non-focusable-by-default elements with tabindex set to a possitive number', function(assert) {
+  this.render(hbs`<div class="target-element" tabindex="0"></div>`);
+  focus('.target-element');
+
+  assert.ok(document.querySelector('.target-element:focus'));
+});
+
+test('it sets focus on non-focusable-by-default elements with tabindex set to a -1', function(assert) {
+  this.render(hbs`<div class="target-element" tabindex="-1"></div>`);
+  focus('.target-element');
+
+  assert.ok(document.querySelector('.target-element:focus'));
+});
+
+test('it does not set focus for non-contenteditable HTMLElement without tabindex', function(assert) {
   this.render(hbs`<div class="target-element"></div>`);
   focus('.target-element');
 


### PR DESCRIPTION
`<div tabindex="0">` should be focusable.

/cc @xcambar 