### PR TITLE
Simplify `waitUntil`

### DIFF
--- a/addon-test-support/wait-until.js
+++ b/addon-test-support/wait-until.js
@@ -3,13 +3,8 @@ import RSVP from 'rsvp';
 
 export function waitUntil(callback, { timeout = 1000 } = {}) {
   return new RSVP.Promise(function(resolve, reject) {
-    let value = run(callback);
-    if (value) {
-      resolve(value);
-      return;
-    }
     let time = 0;
-    let tick = function() {
+    function tick() {
       time += 10;
       let value = run(callback);
       if (value) {


### PR DESCRIPTION
Was working on migrating this to `@ember/test-helpers` starting with the initial implementation here and simplified it a bit.