### PR TITLE
Use built-in `Element.isContentEditable` property

### DIFF
--- a/addon-test-support/-private/is-content-editable.js
+++ b/addon-test-support/-private/is-content-editable.js
@@ -1,3 +1,0 @@
-export default function isContentEditable(el) {
-  return el.contentEditable === 'true';
-}

--- a/addon-test-support/-private/is-focusable.js
+++ b/addon-test-support/-private/is-focusable.js
@@ -1,10 +1,9 @@
 import isFormControl from './is-form-control';
-import isContentEditable from './is-content-editable';
 
 export default function isFocusable(el) {
   let focusableTags = ['LINK', 'A'];
 
-  if (isFormControl(el) || isContentEditable(el) || focusableTags.indexOf(el.tagName) > -1) {
+  if (isFormControl(el) || el.isContentEditable || focusableTags.indexOf(el.tagName) > -1) {
     return true;
   }
 

--- a/addon-test-support/fill-in.js
+++ b/addon-test-support/fill-in.js
@@ -1,7 +1,6 @@
 import { run } from '@ember/runloop';
 import getElementWithAssert from './-private/get-element-with-assert';
 import isFormControl from './-private/is-form-control';
-import isContentEditable from './-private/is-content-editable';
 import { focus } from './focus';
 import { fireEvent } from './fire-event';
 import wait from 'ember-test-helpers/wait';
@@ -16,13 +15,13 @@ import wait from 'ember-test-helpers/wait';
 export function fillIn(selector, text) {
   let el = getElementWithAssert(selector);
 
-  if (!isFormControl(el) && !isContentEditable(el)) {
+  if (!isFormControl(el) && !el.isContentEditable) {
     throw new Error('Unable to fill element');
   }
 
   run(() => focus(el));
   run(() => {
-    if (isContentEditable(el)) {
+    if (el.isContentEditable) {
       el.innerHTML = text;
     } else {
       el.value = text;


### PR DESCRIPTION
Reference: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/isContentEditable
Closes #133