### PR TITLE
Add deprecations for methods that are now in @ember/test-helpers

### DIFF
--- a/addon-test-support/click.js
+++ b/addon-test-support/click.js
@@ -3,6 +3,7 @@ import getElementWithAssert from './-private/get-element-with-assert';
 import { fireEvent } from './fire-event';
 import { focus } from './focus';
 import wait from 'ember-test-helpers/wait';
+import { deprecate } from '@ember/debug';
 
 /*
   @method clickEventSequence
@@ -24,6 +25,11 @@ export function clickEventSequence(el, options) {
   @public
 */
 export function click(selector, context, options) {
+  deprecate(
+    'Importing `click` from "ember-native-dom-helpers" is deprecated. Since `ember-cli-qunit` 4.3 and `ember-cli-mocha` 0.15.0 you can use `import { click } from "@ember/test-helpers";`',
+    false,
+    { until: '0.7', id: 'ember-native-dom-helpers-click' }
+  );
   let element;
   if (context instanceof HTMLElement) {
     element = getElementWithAssert(selector, context);

--- a/addon-test-support/current-path.js
+++ b/addon-test-support/current-path.js
@@ -1,4 +1,11 @@
+import { deprecate } from '@ember/debug';
+
 export function currentPath() {
+  deprecate(
+    'Importing `currentPath` from "ember-native-dom-helpers" is deprecated. Since `ember-cli-qunit` 4.3 and `ember-cli-mocha` 0.15.0 you can use `import { currentPath } from "@ember/test-helpers";`',
+    false,
+    { until: '0.7', id: 'ember-native-dom-helpers-current-path' }
+  );
   if (!window.currentPath) {
     throw new Error('currentPath is only available during acceptance tests');
   }

--- a/addon-test-support/current-route-name.js
+++ b/addon-test-support/current-route-name.js
@@ -1,4 +1,11 @@
+import { deprecate } from '@ember/debug';
+
 export function currentRouteName() {
+  deprecate(
+    'Importing `currentRouteName` from "ember-native-dom-helpers" is deprecated. Since `ember-cli-qunit` 4.3 and `ember-cli-mocha` 0.15.0 you can use `import { currentRouteName } from "@ember/test-helpers";`',
+    false,
+    { until: '0.7', id: 'ember-native-dom-helpers-current-route-name' }
+  );
   if (!window.currentRouteName) {
     throw new Error('currentRouteName is only available during acceptance tests');
   }

--- a/addon-test-support/current-url.js
+++ b/addon-test-support/current-url.js
@@ -1,4 +1,11 @@
+import { deprecate } from '@ember/debug';
+
 export function currentURL() {
+  deprecate(
+    'Importing `currentURL` from "ember-native-dom-helpers" is deprecated. Since `ember-cli-qunit` 4.3 and `ember-cli-mocha` 0.15.0 you can use `import { currentURL } from "@ember/test-helpers";`',
+    false,
+    { until: '0.7', id: 'ember-native-dom-helpers-current-url' }
+  );
   if (!window.currentURL) {
     throw new Error('currentURL is only available during acceptance tests');
   }

--- a/addon-test-support/fill-in.js
+++ b/addon-test-support/fill-in.js
@@ -4,6 +4,7 @@ import isFormControl from './-private/is-form-control';
 import { focus } from './focus';
 import { fireEvent } from './fire-event';
 import wait from 'ember-test-helpers/wait';
+import { deprecate } from '@ember/debug';
 
 /*
   @method fillIn
@@ -13,6 +14,12 @@ import wait from 'ember-test-helpers/wait';
   @public
 */
 export function fillIn(selector, text) {
+  deprecate(
+    'Importing `fillIn` from "ember-native-dom-helpers" is deprecated. Since `ember-cli-qunit` 4.3 and `ember-cli-mocha` 0.15.0 you can use `import { fillIn } from "@ember/test-helpers";`',
+    false,
+    { until: '0.7', id: 'ember-native-dom-helpers-fill-in' }
+  );
+
   let el = getElementWithAssert(selector);
 
   if (!isFormControl(el) && !el.isContentEditable) {

--- a/addon-test-support/key-event.js
+++ b/addon-test-support/key-event.js
@@ -1,5 +1,6 @@
 import { merge } from '@ember/polyfills';
 import { triggerEvent } from './trigger-event';
+import { deprecate } from '@ember/debug';
 
 /**
  * @public
@@ -10,5 +11,10 @@ import { triggerEvent } from './trigger-event';
  * @return {*}
  */
 export function keyEvent(selector, type, keyCode, modifiers = { ctrlKey: false, altKey: false, shiftKey: false, metaKey: false }) {
+  deprecate(
+    'Importing `keyEvent` from "ember-native-dom-helpers" is deprecated. Since `ember-cli-qunit` 4.3 and `ember-cli-mocha` 0.15.0 you can use `import { triggerKeyEvent } from "@ember/test-helpers";`',
+    false,
+    { until: '0.7', id: 'ember-native-dom-helpers-key-event' }
+  );
   return triggerEvent(selector, type, merge({ keyCode, which: keyCode, key: keyCode }, modifiers));
 }

--- a/addon-test-support/visit.js
+++ b/addon-test-support/visit.js
@@ -1,4 +1,12 @@
+import { deprecate } from '@ember/debug';
+
 export function visit() {
+  deprecate(
+    'Importing `visit` from "ember-native-dom-helpers" is deprecated. Since `ember-cli-qunit` 4.3 and `ember-cli-mocha` 0.15.0 you can use `import { visit } from "@ember/test-helpers";`',
+    false,
+    { until: '0.7', id: 'ember-native-dom-helpers-visit' }
+  );
+
   if (!window.visit) {
     throw new Error('visit is only available during acceptance tests');
   }

--- a/addon-test-support/wait-until.js
+++ b/addon-test-support/wait-until.js
@@ -1,7 +1,14 @@
 import { run } from '@ember/runloop';
 import RSVP from 'rsvp';
+import { deprecate } from '@ember/debug';
 
 export function waitUntil(callback, { timeout = 1000 } = {}) {
+  deprecate(
+    'Importing `waitUntil` from "ember-native-dom-helpers" is deprecated. Since `ember-cli-qunit` 4.3 and `ember-cli-mocha` 0.15.0 you can use `import { waitUntil } from "@ember/test-helpers";`',
+    false,
+    { until: '0.7', id: 'ember-native-dom-helpers-wait-until' }
+  );
+
   return new RSVP.Promise(function(resolve, reject) {
     let value = run(callback);
     if (value) {

--- a/testem.js
+++ b/testem.js
@@ -16,6 +16,7 @@ module.exports = {
       '-headless'
     ],
     Chrome: [
+      process.env.TRAVIS ? '--no-sandbox' : null,
       '--touch-events',
       '--disable-gpu',
       '--headless',


### PR DESCRIPTION
@Turbo87 Any idea on how to add conditional deprecations only if the user has a modern versions of ember-cli-qunit/mocha?

Perhaps it's not that bad that we display it unconditionally. AFAIK there is no breaking change in those new versions of qunit and using the new testing API is completely optional, so it might help with adoption.